### PR TITLE
Implement feedback for Undo/Redo and resolve dry-run PE issues

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -120,7 +120,7 @@ This is where you can type your command. The maximum you can type is 60 characte
 
 * Words that are enclosed with `<` and `>` are the parameters to be supplied by the user e.g. in `set reminder|<index>|<reminder threshold>`, `<index>` and `<reminder threshold>` are parameters which can be used as `set reminder|1|7`.
 * Parameters in square brackets are optional e.g `check[|<days>]` can be used as `check|7` or `check`.
-* Optional parameters with `…`​ after them can be used multiple times including zero times e.g. `tag|<index>|[<tag>]...` can be used as `tag|1|#Fruit #Frozen #Cold`, `tag|1`, or `tag|1|#Fruit`.
+* Optional parameters with `…`​ after them can be used multiple times including zero times. For example, for [<other tags>]..., the following format for Tag Command: `tag|<index>|<tag>[<other tags>]...` can be used as `tag|1|#Fruit #Frozen #Cold` or `tag|1|#Fruit`.
 * Trailing `|` (s) are allowed. e.g. `add|banana|2/2/2020|||` or `sort|name|`.
 ====
 
@@ -486,7 +486,7 @@ Undo the previous command that you have entered in. +
 Format: `undo`
 
 [TIP]
-`undo` only works on commands that alter your items. Thus, commands such as `help` and `sort` are not undoable.
+`undo` only works on commands that alter your items or the current view list. Thus, commands such as `help` and `sort` are not undoable as they do not alter items or the current view list.
 
 ==== Redo an earlier command : `redo`
 Redo an earlier command that you have entered in. +

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -120,7 +120,7 @@ This is where you can type your command. The maximum you can type is 60 characte
 
 * Words that are enclosed with `<` and `>` are the parameters to be supplied by the user e.g. in `set reminder|<index>|<reminder threshold>`, `<index>` and `<reminder threshold>` are parameters which can be used as `set reminder|1|7`.
 * Parameters in square brackets are optional e.g `check[|<days>]` can be used as `check|7` or `check`.
-* Optional parameters with `…`​ after them can be used multiple times including zero times. For example, for [<other tags>]..., the following format for Tag Command: `tag|<index>|<tag>[<other tags>]...` can be used as `tag|1|#Fruit #Frozen #Cold` or `tag|1|#Fruit`.
+* Optional parameters with `…`​ after them can be used multiple times including zero times. For example, for [<other tags>]... in the following format for Tag Command: `tag|<index>|<tag>[<other tags>]...` can be used as `tag|1|#Fruit #Frozen #Cold` or `tag|1|#Fruit`.
 * Trailing `|` (s) are allowed. e.g. `add|banana|2/2/2020|||` or `sort|name|`.
 ====
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -366,7 +366,7 @@ Format: `tag`
 image::tag.png[width="790"]
 
 [TIP]
-An item can have any number of tags (including 0)
+An item can have a maximum of 5 tags.
 
 Tags an item from the list according to user input +
 Format: `tag|<index>|<tag>[<other tags>]...`

--- a/src/main/java/io/xpire/logic/LogicManager.java
+++ b/src/main/java/io/xpire/logic/LogicManager.java
@@ -8,6 +8,8 @@ import io.xpire.commons.core.GuiSettings;
 import io.xpire.commons.core.LogsCenter;
 import io.xpire.logic.commands.Command;
 import io.xpire.logic.commands.CommandResult;
+import io.xpire.logic.commands.RedoCommand;
+import io.xpire.logic.commands.UndoCommand;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.logic.parser.Parser;
 import io.xpire.logic.parser.ReplenishParser;
@@ -16,6 +18,7 @@ import io.xpire.logic.parser.exceptions.ParseException;
 import io.xpire.model.Model;
 import io.xpire.model.ReadOnlyListView;
 import io.xpire.model.StackManager;
+import io.xpire.model.history.CommandHistory;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.XpireItem;
 import io.xpire.storage.Storage;
@@ -35,6 +38,7 @@ public class LogicManager implements Logic {
     private final XpireParser xpireParser = new XpireParser();
     private final ReplenishParser replenishParser = new ReplenishParser();
     private final StackManager stackManager = new StackManager();
+    private final CommandHistory commandHistory = new CommandHistory();
 
     public LogicManager(Model model, Storage storage) {
         this.model = model;
@@ -71,6 +75,15 @@ public class LogicManager implements Logic {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }
 
+        if (command instanceof UndoCommand) {
+            Command previousCommand = commandHistory.retrievePreviousCommand();
+            commandResult = new CommandResult(String.format(commandResult.getFeedbackToUser(), previousCommand));
+        } else if (command instanceof RedoCommand) {
+            Command nextCommand = commandHistory.retrieveNextCommand();
+            commandResult = new CommandResult(String.format(commandResult.getFeedbackToUser(), nextCommand));
+        } else {
+            commandHistory.addCommand(command);
+        }
         return commandResult;
     }
 

--- a/src/main/java/io/xpire/logic/LogicManager.java
+++ b/src/main/java/io/xpire/logic/LogicManager.java
@@ -81,7 +81,7 @@ public class LogicManager implements Logic {
         } else if (command instanceof RedoCommand) {
             Command nextCommand = commandHistory.retrieveNextCommand();
             commandResult = new CommandResult(String.format(commandResult.getFeedbackToUser(), nextCommand));
-        } else {
+        } else if (command.isShowInHistory()) {
             commandHistory.addCommand(command);
         }
         return commandResult;

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -24,6 +24,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists";
 
     private final XpireItem toAdd;
+    private String result = "";
 
     /**
      * Creates an AddCommand to add the specified {@code XpireItem}
@@ -48,9 +49,9 @@ public class AddCommand extends Command {
         if (model.hasItem(this.toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_ITEM);
         }
-
         model.addItem(this.toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, this.toAdd));
+        this.result = String.format(MESSAGE_SUCCESS, this.toAdd);
+        return new CommandResult(result);
     }
 
     @Override
@@ -72,6 +73,6 @@ public class AddCommand extends Command {
 
     @Override
     public String toString() {
-        return "Add Command: " + this.toAdd;
+        return "the following Add command:\n" + result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -51,7 +51,7 @@ public class AddCommand extends Command {
         }
         model.addItem(this.toAdd);
         this.result = String.format(MESSAGE_SUCCESS, this.toAdd);
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -51,6 +51,7 @@ public class AddCommand extends Command {
         }
         model.addItem(this.toAdd);
         this.result = String.format(MESSAGE_SUCCESS, this.toAdd);
+        this.showInHistory = true;
         return new CommandResult(result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -18,7 +18,7 @@ public class CheckCommand extends Command {
     public static final String COMMAND_WORD = "check";
     public static final String COMMAND_SHORTHAND = "ch";
 
-    public static final String MESSAGE_SUCCESS = "Item(s) expiring soon";
+    public static final String MESSAGE_SUCCESS = "Item(s) expiring soon.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays all items whose expiry date is within"
             + "the specified duration (in days). Expired items, if any, are also included in the list.\n"
@@ -28,15 +28,18 @@ public class CheckCommand extends Command {
             + "has been activated will be displayed.";
 
     public static final String MESSAGE_EXCEEDED_MAX = "Maximum number of days that can be checked is 36500 days";
+    private String result;
 
     private final Predicate<XpireItem> predicate;
 
-    public CheckCommand(ExpiringSoonPredicate predicate) {
+    public CheckCommand(ExpiringSoonPredicate predicate, int days) {
         this.predicate = predicate;
+        this.result = String.format("Check items with %d days left before their expiry date.", days);
     }
 
     public CheckCommand(ReminderThresholdExceededPredicate predicate) {
         this.predicate = predicate;
+        this.result = "Check items according to their reminder dates.";
     }
 
     @Override
@@ -67,6 +70,6 @@ public class CheckCommand extends Command {
 
     @Override
     public String toString() {
-        return "Check Command";
+        return "the following Check command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -48,6 +48,7 @@ public class CheckCommand extends Command {
         State test = new State(model);
         stackManager.saveState(test);
         model.updateFilteredItemList(this.predicate);
+        this.showInHistory = true;
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -48,7 +48,7 @@ public class CheckCommand extends Command {
         State test = new State(model);
         stackManager.saveState(test);
         model.updateFilteredItemList(this.predicate);
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -48,7 +48,7 @@ public class ClearCommand extends Command {
 
     @Override
     public String toString() {
-        return "Clear Command";
+        return "Clear command.";
     }
 
     public String getList() {

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -43,7 +43,7 @@ public class ClearCommand extends Command {
         default:
             break;
         }
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -43,6 +43,7 @@ public class ClearCommand extends Command {
         default:
             break;
         }
+        this.showInHistory = true;
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/Command.java
+++ b/src/main/java/io/xpire/logic/commands/Command.java
@@ -10,6 +10,7 @@ import io.xpire.model.StackManager;
  */
 public abstract class Command {
 
+    boolean showInHistory = false;
     /**
      * Executes the command and returns the result message.
      *
@@ -20,4 +21,12 @@ public abstract class Command {
     public abstract CommandResult execute(Model model,
                                           StackManager stackManager) throws CommandException, ParseException;
 
+    /**
+     * Denotes if the command should be stored in history.
+     *
+     * @return whether the command should be kept in CommandHistory.
+     */
+    public boolean isShowInHistory() {
+        return showInHistory;
+    }
 }

--- a/src/main/java/io/xpire/logic/commands/Command.java
+++ b/src/main/java/io/xpire/logic/commands/Command.java
@@ -10,7 +10,8 @@ import io.xpire.model.StackManager;
  */
 public abstract class Command {
 
-    boolean showInHistory = false;
+    private boolean showInHistory = false;
+
     /**
      * Executes the command and returns the result message.
      *
@@ -27,6 +28,15 @@ public abstract class Command {
      * @return whether the command should be kept in CommandHistory.
      */
     public boolean isShowInHistory() {
-        return showInHistory;
+        return this.showInHistory;
+    }
+
+    /**
+     * Sets showInHistory.
+     *
+     * @param showInHistory appropriate boolean value for showInHistory.
+     */
+    public void setShowInHistory(boolean showInHistory) {
+        this.showInHistory = showInHistory;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/DeleteCommand.java
+++ b/src/main/java/io/xpire/logic/commands/DeleteCommand.java
@@ -95,14 +95,14 @@ public class DeleteCommand extends Command {
         case ITEM:
             model.deleteItem(targetXpireItem);
             this.result = String.format(MESSAGE_DELETE_ITEM_SUCCESS, targetXpireItem);
-            this.showInHistory = true;
+            setShowInHistory(true);
             return new CommandResult(this.result);
         case TAGS:
             assert this.tagSet != null;
             XpireItem newTaggedXpireItem = removeTagsFromItem(new XpireItem(targetXpireItem), this.tagSet);
             model.setItem(targetXpireItem, newTaggedXpireItem);
             this.result = String.format(MESSAGE_DELETE_TAGS_SUCCESS, newTaggedXpireItem);
-            this.showInHistory = true;
+            setShowInHistory(true);
             return new CommandResult(this.result);
         case QUANTITY:
             assert this.quantity != null;
@@ -114,10 +114,11 @@ public class DeleteCommand extends Command {
                 model.shiftItemToReplenishList(newQuantityXpireItem);
                 this.result = String.format(MESSAGE_DELETE_QUANTITY_SUCCESS, quantity.toString(), targetXpireItem)
                         + "\n" + String.format(MESSAGE_REPLENISH_SHIFT_SUCCESS, itemName);
+                setShowInHistory(true);
                 return new CommandResult(this.result);
             }
             this.result = String.format(MESSAGE_DELETE_QUANTITY_SUCCESS, quantity.toString(), targetXpireItem);
-            this.showInHistory = true;
+            setShowInHistory(true);
             return new CommandResult(this.result);
         default:
             throw new CommandException(Messages.MESSAGE_UNKNOWN_DELETE_MODE);

--- a/src/main/java/io/xpire/logic/commands/DeleteCommand.java
+++ b/src/main/java/io/xpire/logic/commands/DeleteCommand.java
@@ -95,12 +95,14 @@ public class DeleteCommand extends Command {
         case ITEM:
             model.deleteItem(targetXpireItem);
             this.result = String.format(MESSAGE_DELETE_ITEM_SUCCESS, targetXpireItem);
+            this.showInHistory = true;
             return new CommandResult(this.result);
         case TAGS:
             assert this.tagSet != null;
             XpireItem newTaggedXpireItem = removeTagsFromItem(new XpireItem(targetXpireItem), this.tagSet);
             model.setItem(targetXpireItem, newTaggedXpireItem);
             this.result = String.format(MESSAGE_DELETE_TAGS_SUCCESS, newTaggedXpireItem);
+            this.showInHistory = true;
             return new CommandResult(this.result);
         case QUANTITY:
             assert this.quantity != null;
@@ -115,6 +117,7 @@ public class DeleteCommand extends Command {
                 return new CommandResult(this.result);
             }
             this.result = String.format(MESSAGE_DELETE_QUANTITY_SUCCESS, quantity.toString(), targetXpireItem);
+            this.showInHistory = true;
             return new CommandResult(this.result);
         default:
             throw new CommandException(Messages.MESSAGE_UNKNOWN_DELETE_MODE);
@@ -182,6 +185,6 @@ public class DeleteCommand extends Command {
 
     @Override
     public String toString() {
-        return "the following Delete command:\n" + result;
+        return "the following Delete command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/DeleteCommand.java
+++ b/src/main/java/io/xpire/logic/commands/DeleteCommand.java
@@ -38,7 +38,7 @@ public class DeleteCommand extends Command {
             + "1) Deletes the item identified by the index number.\n"
             + "Format: delete|<index> (index must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + "|1" + "\n"
-            + "2) Deletes all tags in the item identified by the index number.\n"
+            + "2) Deletes 1 or more tags specified from the item identified by the index number.\n"
             + "Format: delete|<index>|<tag>[<other tags>]...\n"
             + "Example: " + COMMAND_WORD + "|1" + "|#Fruit #Food"
             + "3) Reduces the quantity in the item identified by the index number. \n"

--- a/src/main/java/io/xpire/logic/commands/RedoCommand.java
+++ b/src/main/java/io/xpire/logic/commands/RedoCommand.java
@@ -2,6 +2,7 @@ package io.xpire.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
 import io.xpire.model.StackManager;
 import io.xpire.model.state.State;
@@ -12,14 +13,14 @@ import io.xpire.model.state.State;
 public class RedoCommand extends Command {
 
     public static final String COMMAND_WORD = "redo";
-    public static final String MESSAGE_REDO_SUCCESS = "Redo earlier command.";
+    public static final String MESSAGE_REDO_SUCCESS = "Redo %s";
     public static final String MESSAGE_REDO_FAILURE = "There are no commands to redo.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
         requireNonNull(model);
         if (stackManager.isRedoStackEmpty()) {
-            return new CommandResult(MESSAGE_REDO_FAILURE);
+            throw new CommandException(MESSAGE_REDO_FAILURE);
         }
         State succeedingState = stackManager.redo();
         model.update(succeedingState);

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -48,7 +48,7 @@ public class SearchCommand extends Command {
             });
         }
         //@@author
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(sb.toString());
     }
 

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -70,6 +70,6 @@ public class SearchCommand extends Command {
 
     @Override
     public String toString() {
-        return "Search Command";
+        return "Search command.";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -48,6 +48,7 @@ public class SearchCommand extends Command {
             });
         }
         //@@author
+        this.showInHistory = true;
         return new CommandResult(sb.toString());
     }
 

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -73,6 +73,7 @@ public class SetReminderCommand extends Command {
         this.item = xpireItemToSetReminder;
         model.setItem(targetItem, xpireItemToSetReminder);
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
+        this.showInHistory = true;
         if (isThresholdExceeded(daysLeft)) {
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
@@ -114,8 +115,9 @@ public class SetReminderCommand extends Command {
         if (this.threshold.getValue() == 0) {
             return "the following Set Reminder command:\nThe Item " + this.item.getName()
                     + "'s reminder has been disabled.";
+        } else {
+            return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
+                    + "has been set for " + this.threshold + " day(s).";
         }
-        return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
-                + "has been set for " + this.threshold + " day(s).";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -31,9 +31,9 @@ public class SetReminderCommand extends Command {
             + "Existing threshold will be overwritten by the input.\n"
             + "Format: set reminder|<index>|<threshold> (both index and threshold must be positive numbers)\n"
             + "Example: " + COMMAND_WORD + "|1|7";
-    public static final String MESSAGE_SUCCESS_SET = "Reminder for item %d has been set to %s day(s)"
+    public static final String MESSAGE_SUCCESS_SET = "Reminder for item %s has been set to %s day(s)"
             + " before expiry date";
-    public static final String MESSAGE_SUCCESS_RESET = "Disabled reminder for item %d";
+    public static final String MESSAGE_SUCCESS_RESET = "Disabled reminder for item %s";
 
     private final Index index;
     private final ReminderThreshold threshold;
@@ -77,8 +77,8 @@ public class SetReminderCommand extends Command {
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
             return new CommandResult(this.threshold.getValue() > 0
-                    ? String.format(MESSAGE_SUCCESS_SET, this.index.getOneBased(), this.threshold)
-                    : String.format(MESSAGE_SUCCESS_RESET, this.index.getOneBased()));
+                    ? String.format(MESSAGE_SUCCESS_SET, this.item.getName(), this.threshold)
+                    : String.format(MESSAGE_SUCCESS_RESET, this.item.getName()));
         }
     }
 
@@ -111,6 +111,11 @@ public class SetReminderCommand extends Command {
 
     @Override
     public String toString() {
-        return "SetReminder Command: " + this.item.getName() + " Set for " + this.threshold + " days";
+        if (this.threshold.getValue() == 0) {
+            return "the following Set Reminder command:\nThe Item " + this.item.getName()
+                    + "'s reminder has been disabled.";
+        }
+        return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
+                + "has been set for " + this.threshold + " day(s).";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -73,10 +73,11 @@ public class SetReminderCommand extends Command {
         this.item = xpireItemToSetReminder;
         model.setItem(targetItem, xpireItemToSetReminder);
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
-        this.showInHistory = true;
         if (isThresholdExceeded(daysLeft)) {
+            setShowInHistory(true);
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
+            setShowInHistory(true);
             return new CommandResult(this.threshold.getValue() > 0
                     ? String.format(MESSAGE_SUCCESS_SET, this.item.getName(), this.threshold)
                     : String.format(MESSAGE_SUCCESS_RESET, this.item.getName()));

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -68,7 +68,7 @@ public class ShiftToMainCommand extends Command {
             model.deleteReplenishItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, toShiftItem.getName());
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -40,6 +40,7 @@ public class ShiftToMainCommand extends Command {
     private final Index targetIndex;
     private final ExpiryDate expiryDate;
     private final Quantity quantity;
+    private String result = "";
 
     public ShiftToMainCommand(Index targetIndex, ExpiryDate expiryDate, Quantity quantity) {
         this.targetIndex = targetIndex;
@@ -66,7 +67,8 @@ public class ShiftToMainCommand extends Command {
             model.addItem(toShiftItem);
             model.deleteReplenishItem(targetItem);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toShiftItem.getName()));
+        this.result = String.format(MESSAGE_SUCCESS, toShiftItem.getName());
+        return new CommandResult(this.result);
     }
 
     /**
@@ -86,5 +88,10 @@ public class ShiftToMainCommand extends Command {
             }
         }
         return new XpireItem(itemName, expiryDate, quantity, newTags);
+    }
+
+    @Override
+    public String toString() {
+        return "the following Shift command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -68,6 +68,7 @@ public class ShiftToMainCommand extends Command {
             model.deleteReplenishItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, toShiftItem.getName());
+        this.showInHistory = true;
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -69,7 +69,7 @@ public class ShiftToReplenishCommand extends Command {
             model.deleteItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, replenishItem.getName());
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -38,6 +38,7 @@ public class ShiftToReplenishCommand extends Command {
 
     private Item replenishItem;
     private final Index targetIndex;
+    private String result = "";
 
     public ShiftToReplenishCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
@@ -67,7 +68,8 @@ public class ShiftToReplenishCommand extends Command {
             model.addReplenishItem(this.replenishItem);
             model.deleteItem(targetItem);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, replenishItem.getName()));
+        this.result = String.format(MESSAGE_SUCCESS, replenishItem.getName());
+        return new CommandResult(this.result);
     }
 
     /**
@@ -85,5 +87,10 @@ public class ShiftToReplenishCommand extends Command {
             }
         }
         return new Item(itemName, newTags);
+    }
+
+    @Override
+    public String toString() {
+        return "the following Shift command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -69,6 +69,7 @@ public class ShiftToReplenishCommand extends Command {
             model.deleteItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, replenishItem.getName());
+        this.showInHistory = true;
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -56,6 +56,7 @@ public class TagCommand extends Command {
     private final TagMode mode;
     private boolean containsLongTags = false;
     private Item item = null;
+    private String result = "";
 
 
 
@@ -101,9 +102,11 @@ public class TagCommand extends Command {
             stackManager.saveState(new State(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
             if (containsLongTags) {
-                return new CommandResult(String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem));
+                this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
+                return new CommandResult(this.result);
             }
-            return new CommandResult(String.format(MESSAGE_TAG_ITEM_SUCCESS, taggedXpireItem));
+            this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS, taggedXpireItem);
+            return new CommandResult(this.result);
 
         case SHOW:
             Set<Tag> tagSet = new TreeSet<>(new TagComparator());

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -40,7 +40,7 @@ public class TagCommand extends Command {
 
             + ": Tags the xpireItem identified by the index number used in the displayed item list.\n"
             + "Note that only 5 tags are allowed per item. \n"
-            + "Format: <index>|<tag>[<other tags>]...\n"
+            + "Format: tag|<index>|<tag>[<other tags>]...\n"
             + "(index must be a positive integer; each tag must be prefixed with a '#')\n"
             + "Example: " + COMMAND_WORD + "|1|#Food #Fruit";
 

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -101,12 +101,13 @@ public class TagCommand extends Command {
             }
             stackManager.saveState(new State(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
-            this.showInHistory = true;
             if (containsLongTags) {
                 this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
+                setShowInHistory(true);
                 return new CommandResult(this.result);
             }
             this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS, taggedXpireItem);
+            setShowInHistory(true);
             return new CommandResult(this.result);
 
         case SHOW:

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -101,6 +101,7 @@ public class TagCommand extends Command {
             }
             stackManager.saveState(new State(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
+            this.showInHistory = true;
             if (containsLongTags) {
                 this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
                 return new CommandResult(this.result);
@@ -202,6 +203,11 @@ public class TagCommand extends Command {
         return index.equals(e.index)
                 && tagItemDescriptor.equals(e.tagItemDescriptor)
                 && mode.equals(e.mode);
+    }
+
+    @Override
+    public String toString() {
+        return "the following Tag command:\n" + this.result;
     }
 
 }

--- a/src/main/java/io/xpire/logic/commands/UndoCommand.java
+++ b/src/main/java/io/xpire/logic/commands/UndoCommand.java
@@ -2,6 +2,7 @@ package io.xpire.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
 import io.xpire.model.StackManager;
 import io.xpire.model.state.State;
@@ -12,14 +13,14 @@ import io.xpire.model.state.State;
 public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
-    public static final String MESSAGE_UNDO_SUCCESS = "Undo previous command.";
+    public static final String MESSAGE_UNDO_SUCCESS = "Undo %s";
     public static final String MESSAGE_UNDO_FAILURE = "There are no previous commands to undo.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
         requireNonNull(model);
         if (stackManager.isUndoStackEmpty()) {
-            return new CommandResult(MESSAGE_UNDO_FAILURE);
+            throw new CommandException(MESSAGE_UNDO_FAILURE);
         }
         State previousState = stackManager.undo(new State(model));
         model.update(previousState);

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -50,6 +50,6 @@ public class ViewCommand extends Command {
 
     @Override
     public String toString() {
-        return "View Command";
+        return "View command.";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -41,7 +41,7 @@ public class ViewCommand extends Command {
             model.setCurrentFilteredItemList(list);
         }
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(output);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -41,6 +41,7 @@ public class ViewCommand extends Command {
             model.setCurrentFilteredItemList(list);
         }
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
+        this.showInHistory = true;
         return new CommandResult(output);
     }
 

--- a/src/main/java/io/xpire/logic/parser/CheckCommandParser.java
+++ b/src/main/java/io/xpire/logic/parser/CheckCommandParser.java
@@ -35,7 +35,7 @@ public class CheckCommandParser implements Parser<CheckCommand> {
         if (StringUtil.isExceedingMaxValue(trimmedArgs, MAX_VALUE)) {
             throw new ParseException(CheckCommand.MESSAGE_EXCEEDED_MAX);
         }
-
-        return new CheckCommand(new ExpiringSoonPredicate(Integer.parseInt(trimmedArgs)));
+        int days = Integer.parseInt(trimmedArgs);
+        return new CheckCommand(new ExpiringSoonPredicate(days), days);
     }
 }

--- a/src/main/java/io/xpire/logic/parser/TagCommandParser.java
+++ b/src/main/java/io/xpire/logic/parser/TagCommandParser.java
@@ -26,14 +26,13 @@ public class TagCommandParser implements Parser<TagCommand> {
         requireNonNull(args);
         String[] splitArgs = args.split("\\|", 2);
         Index index;
-        if (splitArgs[0].isEmpty()) {
+        if (args.isEmpty()) {
             return new TagCommand();
         }
         try {
             index = ParserUtil.parseIndex(splitArgs[0]);
         } catch (ParseException pe) {
-            throw new ParseException(String
-                    .format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
         }
         Set<Tag> set;
         TagItemDescriptor tagItemDescriptor = new TagItemDescriptor();

--- a/src/main/java/io/xpire/model/history/CommandHistory.java
+++ b/src/main/java/io/xpire/model/history/CommandHistory.java
@@ -1,7 +1,52 @@
 package io.xpire.model.history;
 
+import java.util.LinkedList;
+
+import io.xpire.logic.commands.Command;
+
 /**
  * A holder for all the commands.
  */
 public class CommandHistory {
+
+    private final LinkedList<Command> history = new LinkedList<>();
+    private int currentIndex = 0;
+    private int headIndex = 0;
+
+    /**
+     * Retrieves the previous Command and sets the current index back by 1.
+     *
+     * @return previous Command.
+     */
+    public Command retrievePreviousCommand() {
+        currentIndex -= 1;
+        return history.get(currentIndex);
+    }
+
+    /**
+     * Retrieves the next Command and sets the current index forwards by 1.
+     *
+     * @return next Command.
+     */
+    public Command retrieveNextCommand() {
+        Command nextCommand = history.get(currentIndex);
+        currentIndex += 1;
+        return nextCommand;
+    }
+
+    /**
+     * Adds command to history.
+     *
+     * @param command Command to be added to history.
+     */
+    public void addCommand(Command command) {
+        if (headIndex != currentIndex) {
+            for (int i = 0; i < headIndex - currentIndex; i++) {
+                history.removeLast();
+            }
+        }
+        history.add(command);
+        currentIndex += 1;
+        headIndex = currentIndex;
+    }
 }

--- a/src/main/java/io/xpire/storage/JsonAdaptedItem.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedItem.java
@@ -33,6 +33,9 @@ class JsonAdaptedItem {
         this.name = name;
         if (tags != null) {
             this.tags.addAll(tags);
+            while (this.tags.size() > 5) {
+                this.tags.remove(5);
+            }
         }
     }
 

--- a/src/main/java/io/xpire/storage/JsonAdaptedXpireItem.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedXpireItem.java
@@ -47,6 +47,9 @@ class JsonAdaptedXpireItem extends JsonAdaptedItem {
         this.reminderThreshold = reminderThreshold;
         if (tags != null) {
             this.tags.addAll(tags);
+            while (this.tags.size() > 5) {
+                this.tags.remove(5);
+            }
         }
     }
 

--- a/src/test/java/io/xpire/logic/commands/CheckCommandTest.java
+++ b/src/test/java/io/xpire/logic/commands/CheckCommandTest.java
@@ -45,7 +45,7 @@ public class CheckCommandTest {
     public void execute_checkDays_success() {
         String expectedMessage = MESSAGE_SUCCESS;
         ExpiringSoonPredicate predicate = new ExpiringSoonPredicate(5);
-        CheckCommand command = new CheckCommand(predicate);
+        CheckCommand command = new CheckCommand(predicate, 5);
         expectedModel.updateFilteredItemList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(EXPIRED_APPLE, EXPIRED_MILK, EXPIRED_ORANGE), model.getFilteredXpireItemList());
@@ -54,13 +54,13 @@ public class CheckCommandTest {
     @Test
     public void equals() {
         CheckCommand checkReminderCommand = new CheckCommand(new ReminderThresholdExceededPredicate());
-        CheckCommand checkDaysCommand = new CheckCommand(new ExpiringSoonPredicate(5));
+        CheckCommand checkDaysCommand = new CheckCommand(new ExpiringSoonPredicate(5), 5);
 
         // same object -> returns true
         assertTrue(checkReminderCommand.equals(checkReminderCommand));
 
         // same values -> returns true
-        CheckCommand checkDaysCommandCopy = new CheckCommand(new ExpiringSoonPredicate(5));
+        CheckCommand checkDaysCommandCopy = new CheckCommand(new ExpiringSoonPredicate(5), 5);
         assertTrue(checkDaysCommand.equals(checkDaysCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/io/xpire/logic/commands/SetReminderCommandTest.java
+++ b/src/test/java/io/xpire/logic/commands/SetReminderCommandTest.java
@@ -7,6 +7,7 @@ import static io.xpire.logic.commands.SetReminderCommand.MESSAGE_SUCCESS_SET;
 import static io.xpire.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static io.xpire.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 import static io.xpire.testutil.TypicalItems.getTypicalLists;
+import static io.xpire.testutil.TypicalItemsFields.VALID_NAME_BANANA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,7 +72,7 @@ public class SetReminderCommandTest {
         Index secondIndex = INDEX_SECOND_ITEM;
         ReminderThreshold threshold = new ReminderThreshold("1");
         SetReminderCommand command = new SetReminderCommand(secondIndex, threshold);
-        String expectedMessage = String.format(MESSAGE_SUCCESS_SET, secondIndex.getOneBased(), threshold);
+        String expectedMessage = String.format(MESSAGE_SUCCESS_SET, VALID_NAME_BANANA, threshold);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 
@@ -80,7 +81,7 @@ public class SetReminderCommandTest {
         Index secondIndex = INDEX_SECOND_ITEM;
         ReminderThreshold threshold = new ReminderThreshold("0");
         SetReminderCommand command = new SetReminderCommand(secondIndex, threshold);
-        String expectedMessage = String.format(MESSAGE_SUCCESS_RESET, secondIndex.getOneBased());
+        String expectedMessage = String.format(MESSAGE_SUCCESS_RESET, VALID_NAME_BANANA);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 

--- a/src/test/java/io/xpire/logic/parser/CheckCommandParserTest.java
+++ b/src/test/java/io/xpire/logic/parser/CheckCommandParserTest.java
@@ -16,7 +16,7 @@ public class CheckCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsCheckCommand() {
-        assertEqualsParseSuccess(parser, " 1", new CheckCommand(new ExpiringSoonPredicate(1)));
+        assertEqualsParseSuccess(parser, " 1", new CheckCommand(new ExpiringSoonPredicate(1), 1));
         assertEqualsParseSuccess(parser, "", new CheckCommand(new ReminderThresholdExceededPredicate()));
         assertEqualsParseSuccess(parser, " ", new CheckCommand(new ReminderThresholdExceededPredicate()));
     }

--- a/src/test/java/io/xpire/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/io/xpire/logic/parser/TagCommandParserTest.java
@@ -31,7 +31,7 @@ public class TagCommandParserTest {
     @Test
     public void parse_invalidIndex_throwsParserException() {
         assertParseFailure(parser, "-1", String
-                .format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
+                .format(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX, TagCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
Implemented:
CommandHistory that stores in commands and displays appropriate feedback to user for Undo/Redo (This closes #140 )

Issues resolved from dry-run PE:
This closes #178 : Edited UG such that it states only 5 Tags are allowed per item.
This closes #177 : Fixed JsonAdaptedItem/JsonAdaptedXpireItem such that it only accepts a maximum of 5 unique tags in the Json storage file.
This closes #176 : Should not be a bug, however the implementation of CommandHistory will make it clear to users what commands they are undoing/redoing.
This closes #175 : Fixed help message.
This closes #173 : Fixed UG.
This closes #172 : Fixed help message.
This closes #154 : Fixed UG such that it states that Undo/Redo should work for commands that alter items or the current view list. (Will remove when sorting can be redone/undone)
This closes #152 : Fixed it such that weird indices parsed will return an invalid index error message.

To-do:
Write tests for CommandHistory

