### PR TITLE
Implement efficient Undo/Redo

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -486,13 +486,13 @@ Undo the previous command that you have entered in. +
 Format: `undo`
 
 [TIP]
-`undo` only works on commands that alter your items or the current view list. Thus, commands such as `help` and `sort` are not undoable as they do not alter items or the current view list.
+`undo` only works on commands that alter your items or the current view list. Thus, commands such as `help` and `export` are not undoable as they do not alter items or the current view list.
 
 ==== Redo an earlier command : `redo`
 Redo an earlier command that you have entered in. +
 Format: `redo`
 
-This command works in the opposite direction as `undo`, it will redo any command that you have undid so you are able to see the changes.
+This command works in the opposite direction as `undo`, it will redo any command that you have undid so that you are able to see the changes.
 
 == FAQ
 
@@ -611,5 +611,7 @@ Below is a list of commands and their corresponding command shorthands:
 * `delete` : `d`
 * `tag` : `t`
 * `clear` : `cl`
+* `undo` : `u`
+* `redo` : `r`
 * `export` : `ex`
 * `exit` : `x`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -486,7 +486,9 @@ Undo the previous command that you have entered in. +
 Format: `undo`
 
 [TIP]
-`undo` only works on commands that alter your items or the current view list. Thus, commands such as `help` and `export` are not undoable as they do not alter items or the current view list.
+`undo` only works on commands that alter your items or the current view list. +
+Thus, commands such as `help` and `export` are not undoable as they do not alter items or the current view list. +
+Also, `undo` only works for the last 10 commands. Therefore, use the application wisely!
 
 ==== Redo an earlier command : `redo`
 Redo an earlier command that you have entered in. +

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -120,7 +120,7 @@ This is where you can type your command. The maximum you can type is 60 characte
 
 * Words that are enclosed with `<` and `>` are the parameters to be supplied by the user e.g. in `set reminder|<index>|<reminder threshold>`, `<index>` and `<reminder threshold>` are parameters which can be used as `set reminder|1|7`.
 * Parameters in square brackets are optional e.g `check[|<days>]` can be used as `check|7` or `check`.
-* Optional parameters with `…`​ after them can be used multiple times including zero times e.g. `tag|<index>|[<tag>]...` can be used as `tag|1|#Fruit #Frozen #Cold`, `tag|1`, or `tag|1|#Fruit`.
+* Optional parameters with `…`​ after them can be used multiple times including zero times. For example, for [<other tags>]..., the following format for Tag Command: `tag|<index>|<tag>[<other tags>]...` can be used as `tag|1|#Fruit #Frozen #Cold` or `tag|1|#Fruit`.
 * Trailing `|` (s) are allowed. e.g. `add|banana|2/2/2020|||` or `sort|name|`.
 ====
 
@@ -486,7 +486,7 @@ Undo the previous command that you have entered in. +
 Format: `undo`
 
 [TIP]
-`undo` only works on commands that alter your items. Thus, commands such as `help` and `sort` are not undoable.
+`undo` only works on commands that alter your items or the current view list. Thus, commands such as `help` and `sort` are not undoable as they do not alter items or the current view list.
 
 ==== Redo an earlier command : `redo`
 Redo an earlier command that you have entered in. +

--- a/src/main/java/io/xpire/logic/LogicManager.java
+++ b/src/main/java/io/xpire/logic/LogicManager.java
@@ -8,6 +8,8 @@ import io.xpire.commons.core.GuiSettings;
 import io.xpire.commons.core.LogsCenter;
 import io.xpire.logic.commands.Command;
 import io.xpire.logic.commands.CommandResult;
+import io.xpire.logic.commands.RedoCommand;
+import io.xpire.logic.commands.UndoCommand;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.logic.parser.Parser;
 import io.xpire.logic.parser.ReplenishParser;
@@ -16,6 +18,7 @@ import io.xpire.logic.parser.exceptions.ParseException;
 import io.xpire.model.Model;
 import io.xpire.model.ReadOnlyListView;
 import io.xpire.model.StackManager;
+import io.xpire.model.history.CommandHistory;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.XpireItem;
 import io.xpire.storage.Storage;
@@ -35,6 +38,7 @@ public class LogicManager implements Logic {
     private final XpireParser xpireParser = new XpireParser();
     private final ReplenishParser replenishParser = new ReplenishParser();
     private final StackManager stackManager = new StackManager();
+    private final CommandHistory commandHistory = new CommandHistory();
 
     public LogicManager(Model model, Storage storage) {
         this.model = model;
@@ -71,6 +75,15 @@ public class LogicManager implements Logic {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }
 
+        if (command instanceof UndoCommand) {
+            Command previousCommand = commandHistory.retrievePreviousCommand();
+            commandResult = new CommandResult(String.format(commandResult.getFeedbackToUser(), previousCommand));
+        } else if (command instanceof RedoCommand) {
+            Command nextCommand = commandHistory.retrieveNextCommand();
+            commandResult = new CommandResult(String.format(commandResult.getFeedbackToUser(), nextCommand));
+        } else {
+            commandHistory.addCommand(command);
+        }
         return commandResult;
     }
 

--- a/src/main/java/io/xpire/logic/LogicManager.java
+++ b/src/main/java/io/xpire/logic/LogicManager.java
@@ -81,7 +81,7 @@ public class LogicManager implements Logic {
         } else if (command instanceof RedoCommand) {
             Command nextCommand = commandHistory.retrieveNextCommand();
             commandResult = new CommandResult(String.format(commandResult.getFeedbackToUser(), nextCommand));
-        } else {
+        } else if (command.isShowInHistory()) {
             commandHistory.addCommand(command);
         }
         return commandResult;

--- a/src/main/java/io/xpire/logic/LogicManager.java
+++ b/src/main/java/io/xpire/logic/LogicManager.java
@@ -17,10 +17,10 @@ import io.xpire.logic.parser.XpireParser;
 import io.xpire.logic.parser.exceptions.ParseException;
 import io.xpire.model.Model;
 import io.xpire.model.ReadOnlyListView;
-import io.xpire.model.StackManager;
 import io.xpire.model.history.CommandHistory;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.XpireItem;
+import io.xpire.model.state.StateManager;
 import io.xpire.storage.Storage;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -37,7 +37,7 @@ public class LogicManager implements Logic {
     private Parser parser;
     private final XpireParser xpireParser = new XpireParser();
     private final ReplenishParser replenishParser = new ReplenishParser();
-    private final StackManager stackManager = new StackManager();
+    private final StateManager stateManager = new StateManager();
     private final CommandHistory commandHistory = new CommandHistory();
 
     public LogicManager(Model model, Storage storage) {
@@ -58,7 +58,7 @@ public class LogicManager implements Logic {
             this.parser = replenishParser;
         }
         Command command = this.parser.parse(commandText);
-        commandResult = command.execute(this.model, this.stackManager);
+        commandResult = command.execute(this.model, this.stateManager);
 
         //System.out.println("ALLITEMS");
         //this.model.getXpire().getItemList().forEach(System.out::println);

--- a/src/main/java/io/xpire/logic/LogicManager.java
+++ b/src/main/java/io/xpire/logic/LogicManager.java
@@ -60,15 +60,6 @@ public class LogicManager implements Logic {
         Command command = this.parser.parse(commandText);
         commandResult = command.execute(this.model, this.stateManager);
 
-        //System.out.println("ALLITEMS");
-        //this.model.getXpire().getItemList().forEach(System.out::println);
-        //System.out.println("Xpireitem");
-        //this.model.getFilteredXpireItemList().forEach(System.out::println);
-        //System.out.println("currentitem");
-        //this.model.getCurrentFilteredItemList().forEach(System.out::println);
-        //System.out.println("replenishitem");
-        //this.model.getFilteredReplenishItemList().forEach(System.out::println);
-
         try {
             this.storage.saveList(this.model.getLists());
         } catch (IOException ioe) {

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -24,6 +24,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_ITEM = "This item already exists";
 
     private final XpireItem toAdd;
+    private String result = "";
 
     /**
      * Creates an AddCommand to add the specified {@code XpireItem}
@@ -48,9 +49,9 @@ public class AddCommand extends Command {
         if (model.hasItem(this.toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_ITEM);
         }
-
         model.addItem(this.toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, this.toAdd));
+        this.result = String.format(MESSAGE_SUCCESS, this.toAdd);
+        return new CommandResult(result);
     }
 
     @Override
@@ -72,6 +73,6 @@ public class AddCommand extends Command {
 
     @Override
     public String toString() {
-        return "Add Command: " + this.toAdd;
+        return "the following Add command:\n" + result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -51,7 +51,7 @@ public class AddCommand extends Command {
         }
         model.addItem(this.toAdd);
         this.result = String.format(MESSAGE_SUCCESS, this.toAdd);
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -4,9 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.XpireItem;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 
 /**
  * Adds an xpireItem to the list.
@@ -38,13 +38,14 @@ public class AddCommand extends Command {
      * Executes {@code AddCommand}.
      *
      * @param model {@code Model} which the command should operate on.
+     * @param stateManager
      * @return success message from {@code CommandResult} if xpireItem is successfully added.
      * @throws CommandException if xpireItem added is a duplicate.
      */
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new ModifiedState(model));
 
         if (model.hasItem(this.toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_ITEM);

--- a/src/main/java/io/xpire/logic/commands/AddCommand.java
+++ b/src/main/java/io/xpire/logic/commands/AddCommand.java
@@ -51,6 +51,7 @@ public class AddCommand extends Command {
         }
         model.addItem(this.toAdd);
         this.result = String.format(MESSAGE_SUCCESS, this.toAdd);
+        this.showInHistory = true;
         return new CommandResult(result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -18,7 +18,7 @@ public class CheckCommand extends Command {
     public static final String COMMAND_WORD = "check";
     public static final String COMMAND_SHORTHAND = "ch";
 
-    public static final String MESSAGE_SUCCESS = "Item(s) expiring soon";
+    public static final String MESSAGE_SUCCESS = "Item(s) expiring soon.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays all items whose expiry date is within"
             + "the specified duration (in days). Expired items, if any, are also included in the list.\n"
@@ -28,15 +28,18 @@ public class CheckCommand extends Command {
             + "has been activated will be displayed.";
 
     public static final String MESSAGE_EXCEEDED_MAX = "Maximum number of days that can be checked is 36500 days";
+    private String result;
 
     private final Predicate<XpireItem> predicate;
 
-    public CheckCommand(ExpiringSoonPredicate predicate) {
+    public CheckCommand(ExpiringSoonPredicate predicate, int days) {
         this.predicate = predicate;
+        this.result = String.format("Check items with %d days left before their expiry date.", days);
     }
 
     public CheckCommand(ReminderThresholdExceededPredicate predicate) {
         this.predicate = predicate;
+        this.result = "Check items according to their reminder dates.";
     }
 
     @Override
@@ -67,6 +70,6 @@ public class CheckCommand extends Command {
 
     @Override
     public String toString() {
-        return "Check Command";
+        return "the following Check command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -48,6 +48,7 @@ public class CheckCommand extends Command {
         State test = new State(model);
         stackManager.saveState(test);
         model.updateFilteredItemList(this.predicate);
+        this.showInHistory = true;
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -48,7 +48,7 @@ public class CheckCommand extends Command {
         State test = new State(model);
         stackManager.saveState(test);
         model.updateFilteredItemList(this.predicate);
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/CheckCommand.java
+++ b/src/main/java/io/xpire/logic/commands/CheckCommand.java
@@ -5,11 +5,11 @@ import static java.util.Objects.requireNonNull;
 import java.util.function.Predicate;
 
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.ExpiringSoonPredicate;
 import io.xpire.model.item.ReminderThresholdExceededPredicate;
 import io.xpire.model.item.XpireItem;
-import io.xpire.model.state.State;
+import io.xpire.model.state.FilteredState;
+import io.xpire.model.state.StateManager;
 
 /**
  * Displays all items whose expiry date falls within the specified duration (in days).
@@ -43,10 +43,9 @@ public class CheckCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         requireNonNull(model);
-        State test = new State(model);
-        stackManager.saveState(test);
+        stateManager.saveState(new FilteredState(model));
         model.updateFilteredItemList(this.predicate);
         setShowInHistory(true);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -4,9 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.xpire.model.Model;
 import io.xpire.model.ReplenishList;
-import io.xpire.model.StackManager;
 import io.xpire.model.Xpire;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 import javafx.collections.transformation.FilteredList;
 
 /**
@@ -26,9 +26,9 @@ public class ClearCommand extends Command {
 
     //@@author febee99
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new ModifiedState(model));
         switch (list) {
         case "main" :
             model.setXpire(new Xpire());

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -48,7 +48,7 @@ public class ClearCommand extends Command {
 
     @Override
     public String toString() {
-        return "Clear Command";
+        return "Clear command.";
     }
 
     public String getList() {

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -43,7 +43,7 @@ public class ClearCommand extends Command {
         default:
             break;
         }
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -43,6 +43,7 @@ public class ClearCommand extends Command {
         default:
             break;
         }
+        this.showInHistory = true;
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ClearCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ClearCommand.java
@@ -49,7 +49,7 @@ public class ClearCommand extends Command {
 
     @Override
     public String toString() {
-        return "Clear command.";
+        return "Clear command";
     }
 
     public String getList() {

--- a/src/main/java/io/xpire/logic/commands/Command.java
+++ b/src/main/java/io/xpire/logic/commands/Command.java
@@ -10,6 +10,7 @@ import io.xpire.model.StackManager;
  */
 public abstract class Command {
 
+    boolean showInHistory = false;
     /**
      * Executes the command and returns the result message.
      *
@@ -20,4 +21,12 @@ public abstract class Command {
     public abstract CommandResult execute(Model model,
                                           StackManager stackManager) throws CommandException, ParseException;
 
+    /**
+     * Denotes if the command should be stored in history.
+     *
+     * @return whether the command should be kept in CommandHistory.
+     */
+    public boolean isShowInHistory() {
+        return showInHistory;
+    }
 }

--- a/src/main/java/io/xpire/logic/commands/Command.java
+++ b/src/main/java/io/xpire/logic/commands/Command.java
@@ -3,7 +3,7 @@ package io.xpire.logic.commands;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.logic.parser.exceptions.ParseException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
+import io.xpire.model.state.StateManager;
 
 /**
  * Represents a command with hidden internal logic and the ability to be executed.
@@ -16,11 +16,12 @@ public abstract class Command {
      * Executes the command and returns the result message.
      *
      * @param model {@code Model} which the command should operate on.
+     * @param stackManager
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
     public abstract CommandResult execute(Model model,
-                                          StackManager stackManager) throws CommandException, ParseException;
+                                          StateManager stackManager) throws CommandException, ParseException;
 
     /**
      * Denotes if the command should be stored in history.

--- a/src/main/java/io/xpire/logic/commands/Command.java
+++ b/src/main/java/io/xpire/logic/commands/Command.java
@@ -10,7 +10,8 @@ import io.xpire.model.StackManager;
  */
 public abstract class Command {
 
-    boolean showInHistory = false;
+    private boolean showInHistory = false;
+
     /**
      * Executes the command and returns the result message.
      *
@@ -27,6 +28,15 @@ public abstract class Command {
      * @return whether the command should be kept in CommandHistory.
      */
     public boolean isShowInHistory() {
-        return showInHistory;
+        return this.showInHistory;
+    }
+
+    /**
+     * Sets showInHistory.
+     *
+     * @param showInHistory appropriate boolean value for showInHistory.
+     */
+    public void setShowInHistory(boolean showInHistory) {
+        this.showInHistory = showInHistory;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/DeleteCommand.java
+++ b/src/main/java/io/xpire/logic/commands/DeleteCommand.java
@@ -95,14 +95,14 @@ public class DeleteCommand extends Command {
         case ITEM:
             model.deleteItem(targetXpireItem);
             this.result = String.format(MESSAGE_DELETE_ITEM_SUCCESS, targetXpireItem);
-            this.showInHistory = true;
+            setShowInHistory(true);
             return new CommandResult(this.result);
         case TAGS:
             assert this.tagSet != null;
             XpireItem newTaggedXpireItem = removeTagsFromItem(new XpireItem(targetXpireItem), this.tagSet);
             model.setItem(targetXpireItem, newTaggedXpireItem);
             this.result = String.format(MESSAGE_DELETE_TAGS_SUCCESS, newTaggedXpireItem);
-            this.showInHistory = true;
+            setShowInHistory(true);
             return new CommandResult(this.result);
         case QUANTITY:
             assert this.quantity != null;
@@ -114,10 +114,11 @@ public class DeleteCommand extends Command {
                 model.shiftItemToReplenishList(newQuantityXpireItem);
                 this.result = String.format(MESSAGE_DELETE_QUANTITY_SUCCESS, quantity.toString(), targetXpireItem)
                         + "\n" + String.format(MESSAGE_REPLENISH_SHIFT_SUCCESS, itemName);
+                setShowInHistory(true);
                 return new CommandResult(this.result);
             }
             this.result = String.format(MESSAGE_DELETE_QUANTITY_SUCCESS, quantity.toString(), targetXpireItem);
-            this.showInHistory = true;
+            setShowInHistory(true);
             return new CommandResult(this.result);
         default:
             throw new CommandException(Messages.MESSAGE_UNKNOWN_DELETE_MODE);

--- a/src/main/java/io/xpire/logic/commands/DeleteCommand.java
+++ b/src/main/java/io/xpire/logic/commands/DeleteCommand.java
@@ -95,12 +95,14 @@ public class DeleteCommand extends Command {
         case ITEM:
             model.deleteItem(targetXpireItem);
             this.result = String.format(MESSAGE_DELETE_ITEM_SUCCESS, targetXpireItem);
+            this.showInHistory = true;
             return new CommandResult(this.result);
         case TAGS:
             assert this.tagSet != null;
             XpireItem newTaggedXpireItem = removeTagsFromItem(new XpireItem(targetXpireItem), this.tagSet);
             model.setItem(targetXpireItem, newTaggedXpireItem);
             this.result = String.format(MESSAGE_DELETE_TAGS_SUCCESS, newTaggedXpireItem);
+            this.showInHistory = true;
             return new CommandResult(this.result);
         case QUANTITY:
             assert this.quantity != null;
@@ -115,6 +117,7 @@ public class DeleteCommand extends Command {
                 return new CommandResult(this.result);
             }
             this.result = String.format(MESSAGE_DELETE_QUANTITY_SUCCESS, quantity.toString(), targetXpireItem);
+            this.showInHistory = true;
             return new CommandResult(this.result);
         default:
             throw new CommandException(Messages.MESSAGE_UNKNOWN_DELETE_MODE);
@@ -182,6 +185,6 @@ public class DeleteCommand extends Command {
 
     @Override
     public String toString() {
-        return "the following Delete command:\n" + result;
+        return "the following Delete command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/DeleteCommand.java
+++ b/src/main/java/io/xpire/logic/commands/DeleteCommand.java
@@ -12,11 +12,11 @@ import io.xpire.commons.core.index.Index;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.logic.parser.exceptions.ParseException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.Name;
 import io.xpire.model.item.Quantity;
 import io.xpire.model.item.XpireItem;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 import io.xpire.model.tag.Tag;
 import io.xpire.model.tag.TagComparator;
 
@@ -79,9 +79,9 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException, ParseException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException, ParseException {
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new ModifiedState(model));
         List<XpireItem> lastShownList = model.getFilteredXpireItemList();
 
         if (this.targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/io/xpire/logic/commands/ExitCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ExitCommand.java
@@ -1,7 +1,7 @@
 package io.xpire.logic.commands;
 
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
+import io.xpire.model.state.StateManager;
 
 /**
  * Terminates the program.
@@ -14,7 +14,7 @@ public class ExitCommand extends Command {
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Xpire as requested ...";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ExportCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ExportCommand.java
@@ -2,8 +2,8 @@ package io.xpire.logic.commands;
 
 import io.xpire.commons.util.StringUtil;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.Item;
+import io.xpire.model.state.StateManager;
 import javafx.collections.ObservableList;
 
 /**
@@ -22,7 +22,7 @@ public class ExportCommand extends Command {
     private static final String BORDER = "* * * * * * * * * * * * * * * * * * * * * * * * * * * *\n";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         ObservableList<? extends Item> currentList = model.getCurrentFilteredItemList();
         StringBuilder formattedOutput = new StringBuilder(BORDER);
         for (int index = 1; index <= currentList.size(); index++) {

--- a/src/main/java/io/xpire/logic/commands/HelpCommand.java
+++ b/src/main/java/io/xpire/logic/commands/HelpCommand.java
@@ -1,7 +1,7 @@
 package io.xpire.logic.commands;
 
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
+import io.xpire.model.state.StateManager;
 
 /**
  * Format full help instructions for every command for display.
@@ -17,7 +17,7 @@ public class HelpCommand extends Command {
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
 

--- a/src/main/java/io/xpire/logic/commands/RedoCommand.java
+++ b/src/main/java/io/xpire/logic/commands/RedoCommand.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.state.State;
+import io.xpire.model.state.StateManager;
 
 /**
  * Redo the previous Undo Command.
@@ -13,16 +13,17 @@ import io.xpire.model.state.State;
 public class RedoCommand extends Command {
 
     public static final String COMMAND_WORD = "redo";
+    public static final String COMMAND_SHORTHAND = "r";
     public static final String MESSAGE_REDO_SUCCESS = "Redo %s";
     public static final String MESSAGE_REDO_FAILURE = "There are no commands to redo.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
         requireNonNull(model);
-        if (stackManager.isRedoStackEmpty()) {
+        if (stateManager.isRedoStackEmpty()) {
             throw new CommandException(MESSAGE_REDO_FAILURE);
         }
-        State succeedingState = stackManager.redo();
+        State succeedingState = stateManager.redo();
         model.update(succeedingState);
         return new CommandResult(MESSAGE_REDO_SUCCESS);
     }

--- a/src/main/java/io/xpire/logic/commands/RedoCommand.java
+++ b/src/main/java/io/xpire/logic/commands/RedoCommand.java
@@ -2,6 +2,7 @@ package io.xpire.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
 import io.xpire.model.StackManager;
 import io.xpire.model.state.State;
@@ -12,14 +13,14 @@ import io.xpire.model.state.State;
 public class RedoCommand extends Command {
 
     public static final String COMMAND_WORD = "redo";
-    public static final String MESSAGE_REDO_SUCCESS = "Redo earlier command.";
+    public static final String MESSAGE_REDO_SUCCESS = "Redo %s";
     public static final String MESSAGE_REDO_FAILURE = "There are no commands to redo.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
         requireNonNull(model);
         if (stackManager.isRedoStackEmpty()) {
-            return new CommandResult(MESSAGE_REDO_FAILURE);
+            throw new CommandException(MESSAGE_REDO_FAILURE);
         }
         State succeedingState = stackManager.redo();
         model.update(succeedingState);

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -48,7 +48,7 @@ public class SearchCommand extends Command {
             });
         }
         //@@author
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(sb.toString());
     }
 

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -70,6 +70,6 @@ public class SearchCommand extends Command {
 
     @Override
     public String toString() {
-        return "Search Command";
+        return "Search command.";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -71,6 +71,6 @@ public class SearchCommand extends Command {
 
     @Override
     public String toString() {
-        return "Search command.";
+        return "Search command";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -48,6 +48,7 @@ public class SearchCommand extends Command {
             });
         }
         //@@author
+        this.showInHistory = true;
         return new CommandResult(sb.toString());
     }
 

--- a/src/main/java/io/xpire/logic/commands/SearchCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SearchCommand.java
@@ -5,9 +5,9 @@ import static java.util.Objects.requireNonNull;
 import io.xpire.commons.core.Messages;
 import io.xpire.commons.util.StringUtil;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.ContainsKeywordsPredicate;
-import io.xpire.model.state.State;
+import io.xpire.model.state.FilteredState;
+import io.xpire.model.state.StateManager;
 
 /**
  * Searches and displays all items whose name contains any of the argument keywords.
@@ -31,9 +31,9 @@ public class SearchCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new FilteredState(model));
         model.updateFilteredItemList(this.predicate);
         StringBuilder sb = new StringBuilder(String.format(Messages.MESSAGE_ITEMS_LISTED_OVERVIEW,
                 model.getCurrentFilteredItemList().size()));

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -11,10 +11,10 @@ import io.xpire.commons.core.Messages;
 import io.xpire.commons.core.index.Index;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.ReminderThreshold;
 import io.xpire.model.item.XpireItem;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 
 
 /**
@@ -51,9 +51,9 @@ public class SetReminderCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new ModifiedState(model));
         List<XpireItem> lastShownList = model.getFilteredXpireItemList();
 
         if (this.index.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -73,6 +73,7 @@ public class SetReminderCommand extends Command {
         this.item = xpireItemToSetReminder;
         model.setItem(targetItem, xpireItemToSetReminder);
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
+        this.showInHistory = true;
         if (isThresholdExceeded(daysLeft)) {
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
@@ -114,8 +115,9 @@ public class SetReminderCommand extends Command {
         if (this.threshold.getValue() == 0) {
             return "the following Set Reminder command:\nThe Item " + this.item.getName()
                     + "'s reminder has been disabled.";
+        } else {
+            return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
+                    + "has been set for " + this.threshold + " day(s).";
         }
-        return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
-                + "has been set for " + this.threshold + " day(s).";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -31,9 +31,9 @@ public class SetReminderCommand extends Command {
             + "Existing threshold will be overwritten by the input.\n"
             + "Format: set reminder|<index>|<threshold> (both index and threshold must be positive numbers)\n"
             + "Example: " + COMMAND_WORD + "|1|7";
-    public static final String MESSAGE_SUCCESS_SET = "Reminder for item %d has been set to %s day(s)"
+    public static final String MESSAGE_SUCCESS_SET = "Reminder for item %s has been set to %s day(s)"
             + " before expiry date";
-    public static final String MESSAGE_SUCCESS_RESET = "Disabled reminder for item %d";
+    public static final String MESSAGE_SUCCESS_RESET = "Disabled reminder for item %s";
 
     private final Index index;
     private final ReminderThreshold threshold;
@@ -77,8 +77,8 @@ public class SetReminderCommand extends Command {
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
             return new CommandResult(this.threshold.getValue() > 0
-                    ? String.format(MESSAGE_SUCCESS_SET, this.index.getOneBased(), this.threshold)
-                    : String.format(MESSAGE_SUCCESS_RESET, this.index.getOneBased()));
+                    ? String.format(MESSAGE_SUCCESS_SET, this.item.getName(), this.threshold)
+                    : String.format(MESSAGE_SUCCESS_RESET, this.item.getName()));
         }
     }
 
@@ -111,6 +111,11 @@ public class SetReminderCommand extends Command {
 
     @Override
     public String toString() {
-        return "SetReminder Command: " + this.item.getName() + " Set for " + this.threshold + " days";
+        if (this.threshold.getValue() == 0) {
+            return "the following Set Reminder command:\nThe Item " + this.item.getName()
+                    + "'s reminder has been disabled.";
+        }
+        return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
+                + "has been set for " + this.threshold + " day(s).";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -73,10 +73,11 @@ public class SetReminderCommand extends Command {
         this.item = xpireItemToSetReminder;
         model.setItem(targetItem, xpireItemToSetReminder);
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
-        this.showInHistory = true;
         if (isThresholdExceeded(daysLeft)) {
+            setShowInHistory(true);
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
+            setShowInHistory(true);
             return new CommandResult(this.threshold.getValue() > 0
                     ? String.format(MESSAGE_SUCCESS_SET, this.item.getName(), this.threshold)
                     : String.format(MESSAGE_SUCCESS_RESET, this.item.getName()));

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -115,10 +115,10 @@ public class SetReminderCommand extends Command {
     public String toString() {
         if (this.threshold.getValue() == 0) {
             return "the following Set Reminder command:\nThe Item " + this.item.getName()
-                    + "'s reminder has been disabled.";
+                    + "'s reminder has been disabled";
         } else {
             return "the following Set Reminder command:\nThe Item " + this.item.getName() + "'s reminder "
-                    + "has been set for " + this.threshold + " day(s).";
+                    + "has been set for " + this.threshold + " day(s)";
         }
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -1,7 +1,6 @@
 package io.xpire.logic.commands;
 
 import static io.xpire.commons.core.Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX;
-
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -11,13 +10,13 @@ import java.util.TreeSet;
 import io.xpire.commons.core.index.Index;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.ExpiryDate;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.Name;
 import io.xpire.model.item.Quantity;
 import io.xpire.model.item.XpireItem;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 import io.xpire.model.tag.Tag;
 import io.xpire.model.tag.TagComparator;
 
@@ -49,10 +48,10 @@ public class ShiftToMainCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
 
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new ModifiedState(model));
         List<Item> lastShownList = model.getFilteredReplenishItemList();
 
         if (this.targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -68,7 +68,7 @@ public class ShiftToMainCommand extends Command {
             model.deleteReplenishItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, toShiftItem.getName());
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -40,6 +40,7 @@ public class ShiftToMainCommand extends Command {
     private final Index targetIndex;
     private final ExpiryDate expiryDate;
     private final Quantity quantity;
+    private String result = "";
 
     public ShiftToMainCommand(Index targetIndex, ExpiryDate expiryDate, Quantity quantity) {
         this.targetIndex = targetIndex;
@@ -66,7 +67,8 @@ public class ShiftToMainCommand extends Command {
             model.addItem(toShiftItem);
             model.deleteReplenishItem(targetItem);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toShiftItem.getName()));
+        this.result = String.format(MESSAGE_SUCCESS, toShiftItem.getName());
+        return new CommandResult(this.result);
     }
 
     /**
@@ -86,5 +88,10 @@ public class ShiftToMainCommand extends Command {
             }
         }
         return new XpireItem(itemName, expiryDate, quantity, newTags);
+    }
+
+    @Override
+    public String toString() {
+        return "the following Shift command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToMainCommand.java
@@ -68,6 +68,7 @@ public class ShiftToMainCommand extends Command {
             model.deleteReplenishItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, toShiftItem.getName());
+        this.showInHistory = true;
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -10,12 +10,12 @@ import java.util.TreeSet;
 import io.xpire.commons.core.index.Index;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.Name;
 import io.xpire.model.item.XpireItem;
 import io.xpire.model.item.exceptions.ItemNotFoundException;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 import io.xpire.model.tag.Tag;
 import io.xpire.model.tag.TagComparator;
 
@@ -45,10 +45,10 @@ public class ShiftToReplenishCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
 
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new ModifiedState(model));
         List<XpireItem> lastShownList = model.getFilteredXpireItemList();
 
         if (this.targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -69,7 +69,7 @@ public class ShiftToReplenishCommand extends Command {
             model.deleteItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, replenishItem.getName());
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -38,6 +38,7 @@ public class ShiftToReplenishCommand extends Command {
 
     private Item replenishItem;
     private final Index targetIndex;
+    private String result = "";
 
     public ShiftToReplenishCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
@@ -67,7 +68,8 @@ public class ShiftToReplenishCommand extends Command {
             model.addReplenishItem(this.replenishItem);
             model.deleteItem(targetItem);
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, replenishItem.getName()));
+        this.result = String.format(MESSAGE_SUCCESS, replenishItem.getName());
+        return new CommandResult(this.result);
     }
 
     /**
@@ -85,5 +87,10 @@ public class ShiftToReplenishCommand extends Command {
             }
         }
         return new Item(itemName, newTags);
+    }
+
+    @Override
+    public String toString() {
+        return "the following Shift command:\n" + this.result;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ShiftToReplenishCommand.java
@@ -69,6 +69,7 @@ public class ShiftToReplenishCommand extends Command {
             model.deleteItem(targetItem);
         }
         this.result = String.format(MESSAGE_SUCCESS, replenishItem.getName());
+        this.showInHistory = true;
         return new CommandResult(this.result);
     }
 

--- a/src/main/java/io/xpire/logic/commands/SortCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SortCommand.java
@@ -60,6 +60,6 @@ public class SortCommand extends Command {
 
     @Override
     public String toString() {
-        return "Sort Command";
+        return "Sort by " + this.method;
     }
 }

--- a/src/main/java/io/xpire/logic/commands/SortCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SortCommand.java
@@ -3,8 +3,9 @@ package io.xpire.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.sort.XpireMethodOfSorting;
+import io.xpire.model.state.FilteredState;
+import io.xpire.model.state.StateManager;
 
 //@@author febee99
 /**
@@ -31,11 +32,12 @@ public class SortCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         requireNonNull(model);
-        //stackManager.saveState(new State(model, true));
+        stateManager.saveState(new FilteredState(model));
         model.sortItemList(this.method);
         model.updateFilteredItemList(Model.PREDICATE_SORT_ALL_ITEMS);
+        setShowInHistory(true);
         return new CommandResult(MESSAGE_SUCCESS + " by " + method);
     }
 

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -56,6 +56,7 @@ public class TagCommand extends Command {
     private final TagMode mode;
     private boolean containsLongTags = false;
     private Item item = null;
+    private String result = "";
 
 
 
@@ -101,9 +102,11 @@ public class TagCommand extends Command {
             stackManager.saveState(new State(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
             if (containsLongTags) {
-                return new CommandResult(String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem));
+                this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
+                return new CommandResult(this.result);
             }
-            return new CommandResult(String.format(MESSAGE_TAG_ITEM_SUCCESS, taggedXpireItem));
+            this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS, taggedXpireItem);
+            return new CommandResult(this.result);
 
         case SHOW:
             Set<Tag> tagSet = new TreeSet<>(new TagComparator());

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -40,7 +40,7 @@ public class TagCommand extends Command {
 
             + ": Tags the xpireItem identified by the index number used in the displayed item list.\n"
             + "Note that only 5 tags are allowed per item. \n"
-            + "Format: <index>|<tag>[<other tags>]...\n"
+            + "Format: tag|<index>|<tag>[<other tags>]...\n"
             + "(index must be a positive integer; each tag must be prefixed with a '#')\n"
             + "Example: " + COMMAND_WORD + "|1|#Food #Fruit";
 

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -12,10 +12,10 @@ import io.xpire.commons.core.Messages;
 import io.xpire.commons.core.index.Index;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.XpireItem;
-import io.xpire.model.state.State;
+import io.xpire.model.state.ModifiedState;
+import io.xpire.model.state.StateManager;
 import io.xpire.model.tag.Tag;
 import io.xpire.model.tag.TagComparator;
 import io.xpire.model.tag.TagItemDescriptor;
@@ -84,7 +84,7 @@ public class TagCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
         requireNonNull(model);
         List<? extends Item> lastShownList = model.getCurrentFilteredItemList();
 
@@ -99,7 +99,7 @@ public class TagCommand extends Command {
             if (this.tagItemDescriptor.getTags().stream().anyMatch(Tag::isTruncated)) {
                 this.containsLongTags = true;
             }
-            stackManager.saveState(new State(model));
+            stateManager.saveState(new ModifiedState(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
             if (containsLongTags) {
                 this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
@@ -112,7 +112,7 @@ public class TagCommand extends Command {
 
         case SHOW:
             Set<Tag> tagSet = new TreeSet<>(new TagComparator());
-            List<XpireItem> xpireItemList = model.getAllItemList();
+            List<XpireItem> xpireItemList = model.getXpire().getItemList();
             xpireItemList.forEach(item -> tagSet.addAll(item.getTags()));
             if (tagSet.isEmpty()) {
                 return new CommandResult(MESSAGE_TAG_SHOW_FAILURE);

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -101,12 +101,13 @@ public class TagCommand extends Command {
             }
             stackManager.saveState(new State(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
-            this.showInHistory = true;
             if (containsLongTags) {
                 this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
+                setShowInHistory(true);
                 return new CommandResult(this.result);
             }
             this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS, taggedXpireItem);
+            setShowInHistory(true);
             return new CommandResult(this.result);
 
         case SHOW:

--- a/src/main/java/io/xpire/logic/commands/TagCommand.java
+++ b/src/main/java/io/xpire/logic/commands/TagCommand.java
@@ -101,6 +101,7 @@ public class TagCommand extends Command {
             }
             stackManager.saveState(new State(model));
             model.setItem(xpireItemToTag, taggedXpireItem);
+            this.showInHistory = true;
             if (containsLongTags) {
                 this.result = String.format(MESSAGE_TAG_ITEM_SUCCESS_TRUNCATION_WARNING, taggedXpireItem);
                 return new CommandResult(this.result);
@@ -202,6 +203,11 @@ public class TagCommand extends Command {
         return index.equals(e.index)
                 && tagItemDescriptor.equals(e.tagItemDescriptor)
                 && mode.equals(e.mode);
+    }
+
+    @Override
+    public String toString() {
+        return "the following Tag command:\n" + this.result;
     }
 
 }

--- a/src/main/java/io/xpire/logic/commands/UndoCommand.java
+++ b/src/main/java/io/xpire/logic/commands/UndoCommand.java
@@ -2,6 +2,7 @@ package io.xpire.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
 import io.xpire.model.StackManager;
 import io.xpire.model.state.State;
@@ -12,14 +13,14 @@ import io.xpire.model.state.State;
 public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
-    public static final String MESSAGE_UNDO_SUCCESS = "Undo previous command.";
+    public static final String MESSAGE_UNDO_SUCCESS = "Undo %s";
     public static final String MESSAGE_UNDO_FAILURE = "There are no previous commands to undo.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
         requireNonNull(model);
         if (stackManager.isUndoStackEmpty()) {
-            return new CommandResult(MESSAGE_UNDO_FAILURE);
+            throw new CommandException(MESSAGE_UNDO_FAILURE);
         }
         State previousState = stackManager.undo(new State(model));
         model.update(previousState);

--- a/src/main/java/io/xpire/logic/commands/UndoCommand.java
+++ b/src/main/java/io/xpire/logic/commands/UndoCommand.java
@@ -4,8 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
+import io.xpire.model.state.ModifiedState;
 import io.xpire.model.state.State;
+import io.xpire.model.state.StateManager;
 
 /**
  * Undo the previous command.
@@ -13,16 +14,17 @@ import io.xpire.model.state.State;
 public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
+    public static final String COMMAND_SHORTHAND = "u";
     public static final String MESSAGE_UNDO_SUCCESS = "Undo %s";
     public static final String MESSAGE_UNDO_FAILURE = "There are no previous commands to undo.";
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) throws CommandException {
+    public CommandResult execute(Model model, StateManager stateManager) throws CommandException {
         requireNonNull(model);
-        if (stackManager.isUndoStackEmpty()) {
+        if (stateManager.isUndoStackEmpty()) {
             throw new CommandException(MESSAGE_UNDO_FAILURE);
         }
-        State previousState = stackManager.undo(new State(model));
+        State previousState = stateManager.undo(new ModifiedState(model));
         model.update(previousState);
         return new CommandResult(MESSAGE_UNDO_SUCCESS);
     }

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -50,6 +50,6 @@ public class ViewCommand extends Command {
 
     @Override
     public String toString() {
-        return "View Command";
+        return "View command.";
     }
 }

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -1,10 +1,11 @@
 package io.xpire.logic.commands;
+
 import static java.util.Objects.requireNonNull;
 
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.item.ListToView;
-import io.xpire.model.state.State;
+import io.xpire.model.state.FilteredState;
+import io.xpire.model.state.StateManager;
 
 //@@author febee99
 /**
@@ -32,9 +33,9 @@ public class ViewCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, StackManager stackManager) {
+    public CommandResult execute(Model model, StateManager stateManager) {
         requireNonNull(model);
-        stackManager.saveState(new State(model));
+        stateManager.saveState(new FilteredState(model));
         String output = String.format(MESSAGE_SUCCESS, "the");
         if (list != null) {
             output = String.format(MESSAGE_SUCCESS, list);

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -41,7 +41,7 @@ public class ViewCommand extends Command {
             model.setCurrentFilteredItemList(list);
         }
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
-        this.showInHistory = true;
+        setShowInHistory(true);
         return new CommandResult(output);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -41,6 +41,7 @@ public class ViewCommand extends Command {
             model.setCurrentFilteredItemList(list);
         }
         model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
+        this.showInHistory = true;
         return new CommandResult(output);
     }
 

--- a/src/main/java/io/xpire/logic/commands/ViewCommand.java
+++ b/src/main/java/io/xpire/logic/commands/ViewCommand.java
@@ -52,6 +52,6 @@ public class ViewCommand extends Command {
 
     @Override
     public String toString() {
-        return "View command.";
+        return "View command";
     }
 }

--- a/src/main/java/io/xpire/logic/parser/CheckCommandParser.java
+++ b/src/main/java/io/xpire/logic/parser/CheckCommandParser.java
@@ -35,7 +35,7 @@ public class CheckCommandParser implements Parser<CheckCommand> {
         if (StringUtil.isExceedingMaxValue(trimmedArgs, MAX_VALUE)) {
             throw new ParseException(CheckCommand.MESSAGE_EXCEEDED_MAX);
         }
-
-        return new CheckCommand(new ExpiringSoonPredicate(Integer.parseInt(trimmedArgs)));
+        int days = Integer.parseInt(trimmedArgs);
+        return new CheckCommand(new ExpiringSoonPredicate(days), days);
     }
 }

--- a/src/main/java/io/xpire/logic/parser/XpireParser.java
+++ b/src/main/java/io/xpire/logic/parser/XpireParser.java
@@ -113,9 +113,13 @@ public class XpireParser implements Parser {
             return new TagCommandParser().parse(arguments);
 
         case UndoCommand.COMMAND_WORD:
+            //fallthrough
+        case UndoCommand.COMMAND_SHORTHAND:
             return new UndoCommand();
 
         case RedoCommand.COMMAND_WORD:
+            //fallthrough
+        case RedoCommand.COMMAND_SHORTHAND:
             return new RedoCommand();
 
         case ShiftToReplenishCommand.COMMAND_WORD:

--- a/src/main/java/io/xpire/model/CloneModel.java
+++ b/src/main/java/io/xpire/model/CloneModel.java
@@ -19,14 +19,29 @@ public class CloneModel {
     private ListToView listToView;
     private FilteredList<? extends Item> currentList;
 
-    public CloneModel(ReadOnlyListView<XpireItem> xpire, ReadOnlyListView<Item> replenishList,
+    public CloneModel(Xpire xpire, ReadOnlyListView<Item> replenishList,
                       ReadOnlyUserPrefs userPrefs, FilteredList<XpireItem> filteredXpireItemList,
                       FilteredList<Item> filteredReplenishItemList,
                       ListToView listToView, XpireMethodOfSorting method) {
         this.xpire = new Xpire(xpire);
+        this.xpire.setMethodOfSorting(method);
         this.replenishList = new ReplenishList(replenishList);
         this.userPrefs = new UserPrefs(userPrefs);
-        this.xpire.setMethodOfSorting(method);
+        this.filteredXpireItemList = new FilteredList<>(this.xpire.getItemList());
+        this.filteredXpireItemList.setPredicate(filteredXpireItemList.getPredicate());
+        this.filteredReplenishItemList = new FilteredList<>(this.replenishList.getItemList());
+        this.filteredReplenishItemList.setPredicate(filteredReplenishItemList.getPredicate());
+        this.listToView = listToView;
+        this.currentList = checkListToView(this.listToView);
+    }
+
+    public CloneModel(Xpire xpire, ReadOnlyListView<Item> replenishList,
+                      ReadOnlyUserPrefs userPrefs, FilteredList<XpireItem> filteredXpireItemList,
+                      FilteredList<Item> filteredReplenishItemList,
+                      ListToView listToView) {
+        this.xpire = xpire;
+        this.replenishList = replenishList;
+        this.userPrefs = userPrefs;
         this.filteredXpireItemList = new FilteredList<>(this.xpire.getItemList());
         this.filteredXpireItemList.setPredicate(filteredXpireItemList.getPredicate());
         this.filteredReplenishItemList = new FilteredList<>(this.replenishList.getItemList());

--- a/src/main/java/io/xpire/model/Model.java
+++ b/src/main/java/io/xpire/model/Model.java
@@ -73,7 +73,7 @@ public interface Model {
     /**
      * Returns an Xpire object.
      */
-    ReadOnlyListView<XpireItem> getXpire();
+    Xpire getXpire();
 
     /**
      * Returns true if an xpireItem with the same identity as {@code xpireItem} exists in xpire.
@@ -124,13 +124,6 @@ public interface Model {
     FilteredList<? extends Item> getCurrentFilteredItemList();
 
     /**
-     * Returns a list of all the xpire items.
-     *
-     * @return List of all xpire items.
-     */
-    List<XpireItem> getAllItemList();
-
-    /**
      * Updates the filter of the filtered Item list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
@@ -161,7 +154,7 @@ public interface Model {
     /**
      * Returns a ReplenishList object.
      */
-    ReadOnlyListView<Item> getReplenishList();
+    ReplenishList getReplenishList();
 
     /**
      * Returns true if an item with the same identity as {@code Item} exists in replenish list.

--- a/src/main/java/io/xpire/model/ModelManager.java
+++ b/src/main/java/io/xpire/model/ModelManager.java
@@ -4,6 +4,7 @@ import static io.xpire.model.tag.Tag.EXPIRED_TAG;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -51,7 +52,7 @@ public class ModelManager implements Model {
         super();
         CollectionUtil.requireAllNonNull(lists, userPrefs);
 
-        logger.fine("Initializing with xpire: " + lists + " and user prefs " + userPrefs);
+        logger.fine("Initializing with xpire: " + Arrays.toString(lists) + " and user prefs " + userPrefs);
 
         this.xpire = new Xpire(lists[0]);
         this.replenishList = new ReplenishList(lists[1]);
@@ -117,7 +118,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public ReadOnlyListView<XpireItem> getXpire() {
+    public Xpire getXpire() {
         return this.xpire;
     }
 
@@ -171,7 +172,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public ReadOnlyListView<Item> getReplenishList() {
+    public ReplenishList getReplenishList() {
         return this.replenishList;
     }
 
@@ -248,8 +249,8 @@ public class ModelManager implements Model {
     @Override
     public void sortItemList(XpireMethodOfSorting method) {
         requireNonNull(method);
-        update(this.listToView);
         this.xpire.setMethodOfSorting(method);
+        update(this.listToView);
     }
 
     //@@author liawsy
@@ -341,11 +342,6 @@ public class ModelManager implements Model {
     // =========== Tag XpireItem List Accessors =============================================================
 
     @Override
-    public List<XpireItem> getAllItemList() {
-        return this.xpire.getItemList();
-    }
-
-    @Override
     public List<Item> getReplenishItemList() {
         return this.replenishList.getItemList();
     }
@@ -385,6 +381,7 @@ public class ModelManager implements Model {
         CloneModel clone = state.getCloneModel();
         this.setUserPrefs(clone.getUserPrefs());
         this.setXpire(clone.getXpire());
+        this.xpire.setMethodOfSorting(state.getMethod());
         this.setReplenishList(clone.getReplenishList());
         this.setFilteredReplenishItems(clone.getFilteredReplenishItemList());
         this.setFilteredXpireItems(clone.getFilteredXpireItemList());

--- a/src/main/java/io/xpire/model/Xpire.java
+++ b/src/main/java/io/xpire/model/Xpire.java
@@ -92,6 +92,15 @@ public class Xpire implements ReadOnlyListView<XpireItem> {
         this.items.setXpireMethodOfSorting(method);
     }
 
+    /**
+     * Retrieves method of sorting.
+     *
+     * @return Xpire method of sorting.
+     */
+    public XpireMethodOfSorting getMethodOfSorting() {
+        return this.items.getXpireMethodOfSorting();
+    }
+
     //@@author liawsy
     /**
      * Checks expiry date of every item in xpire.

--- a/src/main/java/io/xpire/model/history/CommandHistory.java
+++ b/src/main/java/io/xpire/model/history/CommandHistory.java
@@ -1,7 +1,52 @@
 package io.xpire.model.history;
 
+import java.util.LinkedList;
+
+import io.xpire.logic.commands.Command;
+
 /**
  * A holder for all the commands.
  */
 public class CommandHistory {
+
+    private final LinkedList<Command> history = new LinkedList<>();
+    private int currentIndex = 0;
+    private int headIndex = 0;
+
+    /**
+     * Retrieves the previous Command and sets the current index back by 1.
+     *
+     * @return previous Command.
+     */
+    public Command retrievePreviousCommand() {
+        currentIndex -= 1;
+        return history.get(currentIndex);
+    }
+
+    /**
+     * Retrieves the next Command and sets the current index forwards by 1.
+     *
+     * @return next Command.
+     */
+    public Command retrieveNextCommand() {
+        Command nextCommand = history.get(currentIndex);
+        currentIndex += 1;
+        return nextCommand;
+    }
+
+    /**
+     * Adds command to history.
+     *
+     * @param command Command to be added to history.
+     */
+    public void addCommand(Command command) {
+        if (headIndex != currentIndex) {
+            for (int i = 0; i < headIndex - currentIndex; i++) {
+                history.removeLast();
+            }
+        }
+        history.add(command);
+        currentIndex += 1;
+        headIndex = currentIndex;
+    }
 }

--- a/src/main/java/io/xpire/model/item/SortedUniqueXpireItemList.java
+++ b/src/main/java/io/xpire/model/item/SortedUniqueXpireItemList.java
@@ -57,6 +57,15 @@ public class SortedUniqueXpireItemList implements Iterable<XpireItem> {
     }
 
     /**
+     * Retrieves method of sorting for Xpire.
+     *
+     * @return Xpire method of sorting.
+     */
+    public XpireMethodOfSorting getXpireMethodOfSorting() {
+        return xpireMethodOfSorting;
+    }
+
+    /**
      * Replaces the xpireItem { @code target} in the list with {@code editedXpireItem}.
      * {@code target} must exist in the list.
      * The xpireItem identity of {@code editedXpireItem} must not be the same as another existing xpireItem in the list.
@@ -109,7 +118,7 @@ public class SortedUniqueXpireItemList implements Iterable<XpireItem> {
      */
     public void setXpireMethodOfSorting(XpireMethodOfSorting method) {
         this.xpireMethodOfSorting = method;
-        this.sortedInternalList.setComparator(xpireMethodOfSorting.getComparator());
+        this.sortedInternalList.setComparator(this.xpireMethodOfSorting.getComparator());
     }
 
     /**

--- a/src/main/java/io/xpire/model/item/sort/XpireMethodOfSorting.java
+++ b/src/main/java/io/xpire/model/item/sort/XpireMethodOfSorting.java
@@ -20,6 +20,7 @@ public class XpireMethodOfSorting implements MethodOfSorting<XpireItem> {
     private final Comparator<XpireItem> dateSorter = Comparator.comparing(l->l.getExpiryDate().getDate(),
             Comparator.nullsFirst(Comparator.naturalOrder()));
     private final Comparator<XpireItem> nameThenDateSorter = nameSorter.thenComparing(dateSorter);
+    private final Comparator<XpireItem> dateThenNameSorter = dateSorter.thenComparing(nameSorter);
     private final String method;
 
     /**
@@ -39,7 +40,7 @@ public class XpireMethodOfSorting implements MethodOfSorting<XpireItem> {
     public Comparator<XpireItem> getComparator() {
         switch (method) {
         case "date":
-            return dateSorter;
+            return dateThenNameSorter;
         default:
             return nameThenDateSorter;
         }

--- a/src/main/java/io/xpire/model/state/FilteredState.java
+++ b/src/main/java/io/xpire/model/state/FilteredState.java
@@ -1,0 +1,49 @@
+package io.xpire.model.state;
+
+import io.xpire.model.CloneModel;
+import io.xpire.model.Model;
+import io.xpire.model.item.sort.XpireMethodOfSorting;
+
+/**
+ * State that stores the previous model's Xpire, UserPrefs and the FilteredList.
+ */
+public class FilteredState implements State {
+
+    private XpireMethodOfSorting method;
+    private CloneModel cloneModel;
+
+
+    public FilteredState(Model model) {
+        this.method = model.getXpire().getMethodOfSorting();
+        this.cloneModel = clone(model, this.method);
+    }
+
+    /**
+     * Clones a complete copy of model.
+     */
+    public CloneModel clone(Model model, XpireMethodOfSorting method) {
+        return new CloneModel(model.getXpire(), model.getReplenishList(), model.getUserPrefs(),
+                model.getFilteredXpireItemList(), model.getFilteredReplenishItemList(),
+                model.getListToView());
+    }
+
+    public CloneModel getCloneModel() {
+        return this.cloneModel;
+    }
+
+    public XpireMethodOfSorting getMethod() {
+        return this.method;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof FilteredState)) {
+            return false;
+        } else {
+            FilteredState other = (FilteredState) obj;
+            return other.getCloneModel().equals(this.getCloneModel());
+        }
+    }
+}

--- a/src/main/java/io/xpire/model/state/FilteredState.java
+++ b/src/main/java/io/xpire/model/state/FilteredState.java
@@ -5,7 +5,8 @@ import io.xpire.model.Model;
 import io.xpire.model.item.sort.XpireMethodOfSorting;
 
 /**
- * State that stores the previous model's Xpire, UserPrefs and the FilteredList.
+ * State that stores the previous model's Xpire, UserPrefs and the FilteredList. FilteredState denotes
+ * a state in which the current view has been modified but not the items.
  */
 public class FilteredState implements State {
 

--- a/src/main/java/io/xpire/model/state/ModifiedState.java
+++ b/src/main/java/io/xpire/model/state/ModifiedState.java
@@ -1,0 +1,48 @@
+package io.xpire.model.state;
+
+import io.xpire.model.CloneModel;
+import io.xpire.model.Model;
+import io.xpire.model.item.sort.XpireMethodOfSorting;
+
+/**
+ * State that stores the previous model's Xpire, UserPrefs and the FilteredList.
+ */
+public class ModifiedState implements State {
+
+    private XpireMethodOfSorting method;
+    private CloneModel cloneModel;
+
+    public ModifiedState(Model model) {
+        this.method = model.getXpire().getMethodOfSorting();
+        this.cloneModel = clone(model, this.method);
+    }
+
+    /**
+     * Clones a complete copy of model.
+     */
+    public CloneModel clone(Model model, XpireMethodOfSorting method) {
+        return new CloneModel(model.getXpire(), model.getReplenishList(), model.getUserPrefs(),
+                model.getFilteredXpireItemList(), model.getFilteredReplenishItemList(),
+                model.getListToView(), method);
+    }
+
+    public CloneModel getCloneModel() {
+        return this.cloneModel;
+    }
+
+    public XpireMethodOfSorting getMethod() {
+        return this.method;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof ModifiedState)) {
+            return false;
+        } else {
+            ModifiedState other = (ModifiedState) obj;
+            return other.getCloneModel().equals(this.getCloneModel());
+        }
+    }
+}

--- a/src/main/java/io/xpire/model/state/ModifiedState.java
+++ b/src/main/java/io/xpire/model/state/ModifiedState.java
@@ -5,7 +5,8 @@ import io.xpire.model.Model;
 import io.xpire.model.item.sort.XpireMethodOfSorting;
 
 /**
- * State that stores the previous model's Xpire, UserPrefs and the FilteredList.
+ * State that stores the previous model's Xpire, UserPrefs and the FilteredList. ModifiedState denotes
+ * a state in which all the lists have been modified.
  */
 public class ModifiedState implements State {
 

--- a/src/main/java/io/xpire/model/state/StackManager.java
+++ b/src/main/java/io/xpire/model/state/StackManager.java
@@ -1,8 +1,6 @@
-package io.xpire.model;
+package io.xpire.model.state;
 
 import java.util.Stack;
-
-import io.xpire.model.state.State;
 
 /**
  * A class that wraps two internal stacks that handles Undo/Redo commands.
@@ -20,7 +18,7 @@ public class StackManager {
      * @param currentState current State.
      * @return popped State (most recent State).
      */
-    public State undo(State currentState) {
+    State undo(State currentState) {
         if (isUndoStackEmpty()) {
             return null;
         }
@@ -29,17 +27,13 @@ public class StackManager {
         return current;
     }
 
-    public boolean isDateSorted() {
-        return undoStack.peek().isSortByDate();
-    }
-
     /**
      * Processes the redo command by pushing the current state into the undoStack and
      * returning the state before the previous Undo.
      *
      * @return popped State (previous State).
      */
-    public State redo() {
+    State redo() {
         undoStack.push(current);
         if (isRedoStackEmpty()) {
             return null;
@@ -53,7 +47,7 @@ public class StackManager {
      *
      * @param currentState current State to be saved.
      */
-    public void saveState(State currentState) {
+    void saveState(State currentState) {
         redoStack.clear();
         undoStack.push(currentState);
     }

--- a/src/main/java/io/xpire/model/state/StackManager.java
+++ b/src/main/java/io/xpire/model/state/StackManager.java
@@ -1,5 +1,6 @@
 package io.xpire.model.state;
 
+import java.util.ArrayDeque;
 import java.util.Stack;
 
 /**
@@ -8,7 +9,7 @@ import java.util.Stack;
 public class StackManager {
 
     private static State current;
-    private Stack<State> undoStack = new Stack<>();
+    private ArrayDeque<State> undoStack = new ArrayDeque<>();
     private Stack<State> redoStack = new Stack<>();
 
     /**
@@ -50,6 +51,9 @@ public class StackManager {
     void saveState(State currentState) {
         redoStack.clear();
         undoStack.push(currentState);
+        if (undoStack.size() > StateManager.MAX_STACK_SIZE) {
+            undoStack.removeLast();
+        }
     }
 
     /**

--- a/src/main/java/io/xpire/model/state/State.java
+++ b/src/main/java/io/xpire/model/state/State.java
@@ -5,67 +5,14 @@ import io.xpire.model.Model;
 import io.xpire.model.item.sort.XpireMethodOfSorting;
 
 /**
- * State that stores the previous model's Xpire, UserPrefs and the FilteredList.
+ * An interface State that defines the clone method for modified/filtered states.
  */
-public class State {
+public interface State {
 
-    private XpireMethodOfSorting method = new XpireMethodOfSorting("name");
-    private boolean isSortByDate = false;
-    private CloneModel cloneModel = null;
+    CloneModel clone(Model model, XpireMethodOfSorting method);
 
-    public State(Model model) {
-        this.cloneModel = clone(model);
-    }
+    CloneModel getCloneModel();
 
-    public State(Model model, boolean b) {
-        this.cloneModel = clone(model);
-        isSortByDate = true;
-    }
+    XpireMethodOfSorting getMethod();
 
-    public State(Model model, boolean b, boolean b2) {
-        this.cloneModel = clone(model);
-        isSortByDate = true;
-        setDateSorting();
-    }
-
-    public void setDateSorting() {
-        this.method = new XpireMethodOfSorting("date");
-    }
-
-    public boolean isSortByDate() {
-        return isSortByDate;
-    }
-
-    public void toggle() {
-        isSortByDate = !isSortByDate;
-    }
-
-    /**
-     * Clones a copy of model.
-     */
-    private CloneModel clone(Model model) {
-        return new CloneModel(model.getXpire(), model.getReplenishList(), model.getUserPrefs(),
-                model.getFilteredXpireItemList(), model.getFilteredReplenishItemList(),
-                model.getListToView(), method);
-    }
-
-    public CloneModel getCloneModel() {
-        return cloneModel;
-    }
-
-    public XpireMethodOfSorting getMethod() {
-        return method;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        } else if (!(obj instanceof State)) {
-            return false;
-        } else {
-            State other = (State) obj;
-            return other.getCloneModel().equals(this.getCloneModel());
-        }
-    }
 }

--- a/src/main/java/io/xpire/model/state/StateChecker.java
+++ b/src/main/java/io/xpire/model/state/StateChecker.java
@@ -1,7 +1,0 @@
-package io.xpire.model.state;
-
-/**
- * A checker that processes states and checks for sameness/sorting methods.
- */
-public class StateChecker {
-}

--- a/src/main/java/io/xpire/model/state/StateManager.java
+++ b/src/main/java/io/xpire/model/state/StateManager.java
@@ -5,6 +5,7 @@ package io.xpire.model.state;
  */
 public class StateManager {
 
+    public static final int MAX_STACK_SIZE = 10;
     private StackManager stackManager = new StackManager();
 
     public void saveState(State state) {

--- a/src/main/java/io/xpire/model/state/StateManager.java
+++ b/src/main/java/io/xpire/model/state/StateManager.java
@@ -1,0 +1,30 @@
+package io.xpire.model.state;
+
+/**
+ * A class that handles States accordingly and wraps around StackManager.
+ */
+public class StateManager {
+
+    private StackManager stackManager = new StackManager();
+
+    public void saveState(State state) {
+        stackManager.saveState(state);
+    }
+
+    public boolean isRedoStackEmpty() {
+        return stackManager.isRedoStackEmpty();
+    }
+
+    public boolean isUndoStackEmpty() {
+        return stackManager.isUndoStackEmpty();
+    }
+
+    public State undo(State state) {
+        return stackManager.undo(state);
+    }
+
+    public State redo() {
+        return stackManager.redo();
+    }
+
+}

--- a/src/main/java/io/xpire/storage/JsonAdaptedItem.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedItem.java
@@ -33,6 +33,9 @@ class JsonAdaptedItem {
         this.name = name;
         if (tags != null) {
             this.tags.addAll(tags);
+            while (this.tags.size() > 5) {
+                this.tags.remove(5);
+            }
         }
     }
 

--- a/src/main/java/io/xpire/storage/JsonAdaptedXpireItem.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedXpireItem.java
@@ -47,6 +47,9 @@ class JsonAdaptedXpireItem extends JsonAdaptedItem {
         this.reminderThreshold = reminderThreshold;
         if (tags != null) {
             this.tags.addAll(tags);
+            while (this.tags.size() > 5) {
+                this.tags.remove(5);
+            }
         }
     }
 

--- a/src/test/java/io/xpire/logic/commands/AddCommandTest.java
+++ b/src/test/java/io/xpire/logic/commands/AddCommandTest.java
@@ -46,7 +46,7 @@ import io.xpire.model.Model;
 import io.xpire.model.ReadOnlyListView;
 import io.xpire.model.ReadOnlyUserPrefs;
 import io.xpire.model.ReplenishList;
-import io.xpire.model.StackManager;
+import io.xpire.model.state.StackManager;
 import io.xpire.model.Xpire;
 import io.xpire.model.item.Item;
 import io.xpire.model.item.ListToView;

--- a/src/test/java/io/xpire/logic/commands/CheckCommandTest.java
+++ b/src/test/java/io/xpire/logic/commands/CheckCommandTest.java
@@ -45,7 +45,7 @@ public class CheckCommandTest {
     public void execute_checkDays_success() {
         String expectedMessage = MESSAGE_SUCCESS;
         ExpiringSoonPredicate predicate = new ExpiringSoonPredicate(5);
-        CheckCommand command = new CheckCommand(predicate);
+        CheckCommand command = new CheckCommand(predicate, 5);
         expectedModel.updateFilteredItemList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(EXPIRED_APPLE, EXPIRED_MILK, EXPIRED_ORANGE), model.getFilteredXpireItemList());
@@ -54,13 +54,13 @@ public class CheckCommandTest {
     @Test
     public void equals() {
         CheckCommand checkReminderCommand = new CheckCommand(new ReminderThresholdExceededPredicate());
-        CheckCommand checkDaysCommand = new CheckCommand(new ExpiringSoonPredicate(5));
+        CheckCommand checkDaysCommand = new CheckCommand(new ExpiringSoonPredicate(5), 5);
 
         // same object -> returns true
         assertTrue(checkReminderCommand.equals(checkReminderCommand));
 
         // same values -> returns true
-        CheckCommand checkDaysCommandCopy = new CheckCommand(new ExpiringSoonPredicate(5));
+        CheckCommand checkDaysCommandCopy = new CheckCommand(new ExpiringSoonPredicate(5), 5);
         assertTrue(checkDaysCommand.equals(checkDaysCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/io/xpire/logic/commands/CommandTestUtil.java
+++ b/src/test/java/io/xpire/logic/commands/CommandTestUtil.java
@@ -11,10 +11,10 @@ import io.xpire.commons.core.index.Index;
 import io.xpire.logic.commands.exceptions.CommandException;
 import io.xpire.logic.parser.exceptions.ParseException;
 import io.xpire.model.Model;
-import io.xpire.model.StackManager;
 import io.xpire.model.Xpire;
 import io.xpire.model.item.ContainsKeywordsPredicate;
 import io.xpire.model.item.XpireItem;
+import io.xpire.model.state.StateManager;
 import io.xpire.testutil.Assert;
 
 /**
@@ -23,7 +23,7 @@ import io.xpire.testutil.Assert;
 public class CommandTestUtil {
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
-    private static StackManager stackManager = new StackManager();
+    private static StateManager stateManager = new StateManager();
 
     /**
      * Executes the given {@code command}, confirms that <br>
@@ -33,7 +33,7 @@ public class CommandTestUtil {
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
                                             Model expectedModel) {
         try {
-            CommandResult result = command.execute(actualModel, stackManager);
+            CommandResult result = command.execute(actualModel, stateManager);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException | ParseException ce) {
@@ -63,7 +63,7 @@ public class CommandTestUtil {
         Xpire expectedXpire = new Xpire(actualModel.getLists()[0]);
         List<XpireItem> expectedFilteredList = new ArrayList<>(actualModel.getFilteredXpireItemList());
 
-        Assert.assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel, stackManager));
+        Assert.assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel, stateManager));
         assertEquals(expectedXpire, actualModel.getLists()[0]);
         assertEquals(expectedFilteredList, actualModel.getFilteredXpireItemList());
     }

--- a/src/test/java/io/xpire/logic/commands/SetReminderCommandTest.java
+++ b/src/test/java/io/xpire/logic/commands/SetReminderCommandTest.java
@@ -7,6 +7,7 @@ import static io.xpire.logic.commands.SetReminderCommand.MESSAGE_SUCCESS_SET;
 import static io.xpire.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static io.xpire.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 import static io.xpire.testutil.TypicalItems.getTypicalLists;
+import static io.xpire.testutil.TypicalItemsFields.VALID_NAME_BANANA;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,7 +72,7 @@ public class SetReminderCommandTest {
         Index secondIndex = INDEX_SECOND_ITEM;
         ReminderThreshold threshold = new ReminderThreshold("1");
         SetReminderCommand command = new SetReminderCommand(secondIndex, threshold);
-        String expectedMessage = String.format(MESSAGE_SUCCESS_SET, secondIndex.getOneBased(), threshold);
+        String expectedMessage = String.format(MESSAGE_SUCCESS_SET, VALID_NAME_BANANA, threshold);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 
@@ -80,7 +81,7 @@ public class SetReminderCommandTest {
         Index secondIndex = INDEX_SECOND_ITEM;
         ReminderThreshold threshold = new ReminderThreshold("0");
         SetReminderCommand command = new SetReminderCommand(secondIndex, threshold);
-        String expectedMessage = String.format(MESSAGE_SUCCESS_RESET, secondIndex.getOneBased());
+        String expectedMessage = String.format(MESSAGE_SUCCESS_RESET, VALID_NAME_BANANA);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 

--- a/src/test/java/io/xpire/logic/parser/CheckCommandParserTest.java
+++ b/src/test/java/io/xpire/logic/parser/CheckCommandParserTest.java
@@ -16,7 +16,7 @@ public class CheckCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsCheckCommand() {
-        assertEqualsParseSuccess(parser, " 1", new CheckCommand(new ExpiringSoonPredicate(1)));
+        assertEqualsParseSuccess(parser, " 1", new CheckCommand(new ExpiringSoonPredicate(1), 1));
         assertEqualsParseSuccess(parser, "", new CheckCommand(new ReminderThresholdExceededPredicate()));
         assertEqualsParseSuccess(parser, " ", new CheckCommand(new ReminderThresholdExceededPredicate()));
     }


### PR DESCRIPTION
Implement Shorthand commands for Undo/Redo
Implement Undo/Redo to work on all commands except Export, Exit and Help commands
Set limit on number of Undo Commands to 10
Implement greater abstraction for different States (Filtered/Modified)
Ensure sorting is stable for Undo/Redo
Update UG

This closes #141 .
This PR is a follow-up to the previous PR (#180 ).  

To-do:
Do J-Unit testing