### PR TITLE
Add checks for reading json file

### DIFF
--- a/src/main/java/io/xpire/MainApp.java
+++ b/src/main/java/io/xpire/MainApp.java
@@ -102,6 +102,7 @@ public class MainApp extends Application {
                     SampleDataUtil::getSampleReplenishList
             );
         } catch (DataConversionException e) {
+            logger.warning(e.getMessage());
             logger.warning("Data file not in the correct format. Will be starting with an empty Expiry Date Tracker");
             initialTrackerData = new Xpire();
             initialReplenishData = new ReplenishList();

--- a/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
+++ b/src/main/java/io/xpire/logic/commands/SetReminderCommand.java
@@ -68,35 +68,25 @@ public class SetReminderCommand extends Command {
         }
 
         String daysLeft = xpireItemToSetReminder.getExpiryDate().getStatus();
-        ReminderThreshold finalThreshold = getValidThreshold(daysLeft);
-        xpireItemToSetReminder.setReminderThreshold(finalThreshold);
-        this.item = xpireItemToSetReminder;
-        model.setItem(targetItem, xpireItemToSetReminder);
-        model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
-        if (isThresholdExceeded(daysLeft)) {
-            setShowInHistory(true);
+
+        setShowInHistory(true);
+
+        if (!ReminderThreshold.isValidReminderThreshold(this.threshold.toString(), daysLeft)) {
+            ReminderThreshold newThreshold = new ReminderThreshold(daysLeft);
+            xpireItemToSetReminder.setReminderThreshold(newThreshold);
+            this.item = xpireItemToSetReminder;
+            model.setItem(targetItem, xpireItemToSetReminder);
+            model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
             return new CommandResult(String.format(MESSAGE_REMINDER_THRESHOLD_EXCEEDED, daysLeft));
         } else {
-            setShowInHistory(true);
+            xpireItemToSetReminder.setReminderThreshold(this.threshold);
+            this.item = xpireItemToSetReminder;
+            model.setItem(targetItem, xpireItemToSetReminder);
+            model.updateFilteredItemList(Model.PREDICATE_SHOW_ALL_ITEMS);
             return new CommandResult(this.threshold.getValue() > 0
                     ? String.format(MESSAGE_SUCCESS_SET, this.item.getName(), this.threshold)
                     : String.format(MESSAGE_SUCCESS_RESET, this.item.getName()));
         }
-    }
-
-    private boolean isThresholdExceeded(String daysLeft) {
-        int threshold = this.threshold.getValue();
-        long remainingDays = Long.parseLong(daysLeft);
-        return threshold >= remainingDays;
-    }
-
-    private ReminderThreshold getValidThreshold(String daysLeft) {
-        if (isThresholdExceeded(daysLeft)) {
-            return new ReminderThreshold(daysLeft);
-        } else {
-            return this.threshold;
-        }
-
     }
 
     @Override

--- a/src/main/java/io/xpire/model/item/ExpiryDate.java
+++ b/src/main/java/io/xpire/model/item/ExpiryDate.java
@@ -13,8 +13,8 @@ import io.xpire.commons.util.DateUtil;
  */
 public class ExpiryDate {
     public static final String DATE_FORMAT = "d/M/yyyy";
-    public static final String MESSAGE_CONSTRAINTS_LOWER = "Only Expiry dates that have not yet passed are accepted";
-    public static final String MESSAGE_CONSTRAINTS_UPPER = "Only Expiry dates strictly within 100 years are accepted";
+    public static final String MESSAGE_CONSTRAINTS_LOWER = "Only expiry dates that have not yet passed are accepted";
+    public static final String MESSAGE_CONSTRAINTS_UPPER = "Only expiry dates strictly within 100 years are accepted";
 
     public static final String MESSAGE_CONSTRAINTS_FORMAT =
             "Expiry dates should only contain numbers, in the format " + DATE_FORMAT;

--- a/src/main/java/io/xpire/model/item/ExpiryDate.java
+++ b/src/main/java/io/xpire/model/item/ExpiryDate.java
@@ -14,6 +14,7 @@ import io.xpire.commons.util.DateUtil;
 public class ExpiryDate {
     public static final String DATE_FORMAT = "d/M/yyyy";
     public static final String MESSAGE_CONSTRAINTS_LOWER = "Only expiry dates that have not yet passed are accepted";
+    public static final String MESSAGE_CONSTRAINTS_OUTDATED = "This expiry date is too outdated.";
     public static final String MESSAGE_CONSTRAINTS_UPPER = "Only expiry dates strictly within 100 years are accepted";
 
     public static final String MESSAGE_CONSTRAINTS_FORMAT =
@@ -51,7 +52,7 @@ public class ExpiryDate {
         return d.isAfter(DateUtil.getCurrentDate());
     }
 
-    //@@author
+    //@@author xiaoyu-nus
     /**
      * Returns true if a given string is a valid expiry date within a hundred years.
      */

--- a/src/main/java/io/xpire/model/item/ReminderThreshold.java
+++ b/src/main/java/io/xpire/model/item/ReminderThreshold.java
@@ -12,8 +12,10 @@ import io.xpire.commons.util.StringUtil;
  */
 public class ReminderThreshold {
 
-    public static final String MESSAGE_CONSTRAINTS = "Reminder threshold should be a non-negative integer.";
-    public static final String MESSAGE_QUANTITY_EXCEEDED = "Reminder threshold exceeds maximum input of 36500.";
+    public static final String MESSAGE_CONSTRAINTS = "Reminder threshold should be a non-negative integer"
+            + "no greater than 36500. \n"
+            + "Also, reminder threshold cannot be greater than the number of days left before the item expires";
+    public static final String MESSAGE_CONSTRAINTS_LOWER = "Reminder is too old!";
     public static final String DEFAULT_THRESHOLD = "0";
 
     public static final int MAX_VALUE = 36500;
@@ -37,6 +39,15 @@ public class ReminderThreshold {
     public static boolean isValidReminderThreshold(String test) {
         return StringUtil.isNonNegativeInteger(test)
                 && (!StringUtil.isExceedingMaxValue(test, MAX_VALUE));
+    }
+
+    /**
+     * Returns true if a given integer is a valid reminder threshold and is smaller than given days.
+     */
+    public static boolean isValidReminderThreshold(String test, String days) {
+        int threshold = Integer.parseInt(test);
+        long remainingDays = Long.parseLong(days);
+        return isValidReminderThreshold(test) && threshold < remainingDays;
     }
 
     /**

--- a/src/main/java/io/xpire/storage/JsonAdapted.java
+++ b/src/main/java/io/xpire/storage/JsonAdapted.java
@@ -1,0 +1,16 @@
+package io.xpire.storage;
+
+import io.xpire.commons.exceptions.IllegalValueException;
+
+/**
+ * Jackson-friendly version of object.
+ */
+public interface JsonAdapted {
+
+    /**
+     * Converts this Jackson-friendly adapted object into the xpireModel's object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted object.
+     */
+    Object toModelType() throws IllegalValueException;
+}

--- a/src/main/java/io/xpire/storage/JsonAdaptedItem.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedItem.java
@@ -17,7 +17,7 @@ import io.xpire.model.tag.TagComparator;
 /**
  * Jackson-friendly version of {@link Item}.
  */
-class JsonAdaptedItem {
+class JsonAdaptedItem implements JsonAdapted {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Item's %s field is missing!";
 
@@ -56,6 +56,7 @@ class JsonAdaptedItem {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted item.
      */
+    @Override
     public Item toModelType() throws IllegalValueException {
 
         if (this.name == null) {

--- a/src/main/java/io/xpire/storage/JsonAdaptedTag.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedTag.java
@@ -10,7 +10,7 @@ import io.xpire.model.tag.Tag;
 /**
  * Jackson-friendly version of {@link Tag}.
  */
-class JsonAdaptedTag {
+class JsonAdaptedTag implements JsonAdapted {
 
     private final String tagName;
 
@@ -39,6 +39,7 @@ class JsonAdaptedTag {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
+    @Override
     public Tag toModelType() throws IllegalValueException {
         if (!Tag.isValidTagName(this.tagName)) {
             throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);

--- a/src/main/java/io/xpire/storage/JsonAdaptedXpireItem.java
+++ b/src/main/java/io/xpire/storage/JsonAdaptedXpireItem.java
@@ -100,6 +100,18 @@ class JsonAdaptedXpireItem extends JsonAdaptedItem {
             throw new IllegalValueException(ExpiryDate.MESSAGE_CONSTRAINTS_UPPER);
         }
 
+        /*
+         The following condition ensures that the item's expiry date is no earlier than 100 years ago.
+         Valid expiry date may turn invalid 100 years later.
+         @@author xiaoyu-nus
+         */
+        ExpiryDate expiryDate = new ExpiryDate(this.expiryDate);
+
+        String newDate = DateUtil.convertDateToString(expiryDate.getDate().plusYears(100), "d/M/yyyy");
+        if (!ExpiryDate.isValidLowerRangeExpiryDate(newDate)) {
+            throw new IllegalValueException(ExpiryDate.MESSAGE_CONSTRAINTS_OUTDATED);
+        }
+
         final ExpiryDate modelExpiryDate = new ExpiryDate(this.expiryDate);
 
         if (this.quantity == null) {
@@ -123,6 +135,7 @@ class JsonAdaptedXpireItem extends JsonAdaptedItem {
         /* since the date of creation of the item is known,
             this check assumes the date to be no earlier than 01/10/2019.
             Any reminder threshold that results in the reminder before 01/10/2019 will be rejected.
+            @@author xiaoyu-nus
          */
         String daysSinceRelease = "" + DateUtil.getOffsetDays(LocalDate.of(2019, 10, 1), modelExpiryDate.getDate());
 

--- a/src/test/data/JsonSerializableXpireTest/typicalItemsXpire.json
+++ b/src/test/data/JsonSerializableXpireTest/typicalItemsXpire.json
@@ -3,7 +3,7 @@
   "items" : [
     {
       "name": "Coriander",
-      "expiryDate": "31/12/9999",
+      "expiryDate": "31/12/2099",
       "quantity": "999",
       "reminderThreshold": "2",
       "tags": ["Fridge", "Herb"]

--- a/src/test/java/io/xpire/storage/JsonAdaptedXpireItemTest.java
+++ b/src/test/java/io/xpire/storage/JsonAdaptedXpireItemTest.java
@@ -4,9 +4,12 @@ import static io.xpire.storage.JsonAdaptedXpireItem.MISSING_FIELD_MESSAGE_FORMAT
 import static io.xpire.testutil.Assert.assertThrows;
 import static io.xpire.testutil.TypicalItems.JELLY;
 import static io.xpire.testutil.TypicalItemsFields.INVALID_EXPIRY_DATE;
+import static io.xpire.testutil.TypicalItemsFields.INVALID_EXPIRY_DATE_LOWER;
+import static io.xpire.testutil.TypicalItemsFields.INVALID_EXPIRY_DATE_UPPER;
 import static io.xpire.testutil.TypicalItemsFields.INVALID_NAME;
 import static io.xpire.testutil.TypicalItemsFields.INVALID_QUANTITY;
 import static io.xpire.testutil.TypicalItemsFields.INVALID_REMINDER_THRESHOLD;
+import static io.xpire.testutil.TypicalItemsFields.INVALID_REMINDER_THRESHOLD_RANGE;
 import static io.xpire.testutil.TypicalItemsFields.INVALID_TAG;
 import static io.xpire.testutil.TypicalItemsFields.VALID_EXPIRY_DATE_JELLY;
 import static io.xpire.testutil.TypicalItemsFields.VALID_NAME_JELLY;
@@ -66,6 +69,22 @@ public class JsonAdaptedXpireItemTest {
     }
 
     @Test
+    public void toModelType_invalidExpiryDateUpper_throwsIllegalValueException() {
+        JsonAdaptedXpireItem item = new JsonAdaptedXpireItem(VALID_NAME_JELLY, INVALID_EXPIRY_DATE_UPPER,
+                VALID_QUANTITY_JELLY, VALID_REMINDER_THRESHOLD_JELLY, VALID_TAGS);
+        String expectedMessage = ExpiryDate.MESSAGE_CONSTRAINTS_UPPER;
+        assertThrows(IllegalValueException.class, expectedMessage, item::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidExpiryDateLower_throwsIllegalValueException() {
+        JsonAdaptedXpireItem item = new JsonAdaptedXpireItem(VALID_NAME_JELLY, INVALID_EXPIRY_DATE_LOWER,
+                VALID_QUANTITY_JELLY, VALID_REMINDER_THRESHOLD_JELLY, VALID_TAGS);
+        String expectedMessage = ExpiryDate.MESSAGE_CONSTRAINTS_OUTDATED;
+        assertThrows(IllegalValueException.class, expectedMessage, item::toModelType);
+    }
+
+    @Test
     public void toModelType_nullExpiryDate_throwsIllegalValueException() {
         JsonAdaptedXpireItem item = new JsonAdaptedXpireItem(VALID_NAME_JELLY, null, VALID_QUANTITY_JELLY,
                 VALID_REMINDER_THRESHOLD_JELLY, VALID_TAGS);
@@ -98,6 +117,15 @@ public class JsonAdaptedXpireItemTest {
                 new JsonAdaptedXpireItem(VALID_NAME_JELLY, VALID_EXPIRY_DATE_JELLY, VALID_QUANTITY_JELLY,
                         INVALID_REMINDER_THRESHOLD, VALID_TAGS);
         String expectedMessage = ReminderThreshold.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, item::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidReminderThresholdRange_throwsIllegalValueException() {
+        JsonAdaptedXpireItem item =
+                new JsonAdaptedXpireItem(VALID_NAME_JELLY, VALID_EXPIRY_DATE_JELLY, VALID_QUANTITY_JELLY,
+                        INVALID_REMINDER_THRESHOLD_RANGE, VALID_TAGS);
+        String expectedMessage = ReminderThreshold.MESSAGE_CONSTRAINTS_LOWER;
         assertThrows(IllegalValueException.class, expectedMessage, item::toModelType);
     }
 }

--- a/src/test/java/io/xpire/testutil/TypicalItemsFields.java
+++ b/src/test/java/io/xpire/testutil/TypicalItemsFields.java
@@ -30,7 +30,7 @@ public class TypicalItemsFields {
 
     public static final String VALID_EXPIRY_DATE_APPLE = TODAY;
     public static final String VALID_EXPIRY_DATE_BANANA = IN_TWO_WEEKS;
-    public static final String VALID_EXPIRY_DATE_CORIANDER = "31/12/9999";
+    public static final String VALID_EXPIRY_DATE_CORIANDER = "31/12/2099";
     public static final String VALID_EXPIRY_DATE_DUCK = IN_A_MONTH;
     public static final String VALID_EXPIRY_DATE_KIWI = IN_A_MONTH;
     public static final String VALID_EXPIRY_DATE_JELLY = IN_A_MONTH;
@@ -68,8 +68,11 @@ public class TypicalItemsFields {
     public static final String INVALID_NAME = "@pple";
     public static final String INVALID_EXPIRY_DATE = "50505000";
     public static final String INVALID_EXPIRY_DATE_RANGE = "50/50/5000";
+    public static final String INVALID_EXPIRY_DATE_UPPER = "1/1/9999";
+    public static final String INVALID_EXPIRY_DATE_LOWER = "1/1/1000";
     public static final String INVALID_TAG = "$cold";
     public static final String INVALID_QUANTITY = "-2";
     public static final String INVALID_REMINDER_THRESHOLD = "-5";
+    public static final String INVALID_REMINDER_THRESHOLD_RANGE = "30000";
 
 }


### PR DESCRIPTION
The following are now considered corrupted json item:

- Reminder is before 1/10/2019.
- Expiry date exceeds current date by over 100 years.
- Expiry date is earlier than the current date by over 100 years.

This resolves #179 